### PR TITLE
Add "Dependencies" section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,22 @@ Download
 Latest version can always be found at:
 [https://github.com/nicklan/pnmixer/downloads](https://github.com/nicklan/pnmixer/downloads)
 
+Dependencies
+------------
+
+Development files from the following libraries are required to build PNMixer
+from source:
+
+* glib2.0
+* gtk+2.0
+
+To install them (on a Debian-based system, for example) run:
+
+    aptitude install libglib2.0-dev libgtk2.0-dev
+
+In total, these packages and their dependencies will require approximately 
+**40MB** of disk space, but they can be uninstalled after compilation is 
+complete.
 
 Compilation and Install
 -----------------------


### PR DESCRIPTION
I believe this section improves that documentation by giving users an idea of what is required _prior_ to the building process. It's possible that I missed some deps, but these were the only two that autogen complained about (perhaps some were already installed).
