### PR TITLE
Simplify run_command()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -106,14 +106,14 @@ void run_command(gchar* cmd) {
   if (cmd) {
     GError *error = NULL;
 
+    gtk_widget_hide (popup_window);
+
     if (g_spawn_command_line_async (cmd, &error) == FALSE) {
       report_error(_("Unable to run command %s"), error->message);
       g_error_free (error);
       error = NULL;
     }
   }
-
-  gtk_widget_hide (popup_window);
 }
 
 /**


### PR DESCRIPTION
Just let g_spawn_command_line_async() do the work. This
also allows for more complex command strings wrt #38
and makes two functions obsolete.
