### PR TITLE
Add travis integration. Dep on earlier gtk 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: c
+
+before_install: sudo apt-get update
+
+install: sudo apt-get install libasound2-dev libgtk-3-dev libnotify-dev
+
+script:
+  - ./autogen.sh
+  - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: c
 
+compiler:
+  - clang
+  - gcc
+
 before_install: sudo apt-get update
 
 install: sudo apt-get install libasound2-dev libgtk-3-dev libnotify-dev
 
 script:
-  - ./autogen.sh
+  - ./autogen.sh --enable-debug
   - make

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-PNMixer
+PNMixer [![Build Status](https://travis-ci.org/nicklan/pnmixer.svg?branch=master)](https://travis-ci.org/nicklan/pnmixer)
 =======
 
 PNMixer is a simple mixer application designed to run in your system

--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ AC_ARG_ENABLE([minimal-flags],
 if test x"$debugit" = x"yes"; then
     AC_DEFINE([DEBUG],[],[Debug Mode])
 	if test "$minimalflags" = "no" ; then
-	    CFLAGS="$CFLAGS -g -Wall -Werror -Wno-uninitialized -Wformat -Wformat-security -O0"
+	    CFLAGS="$CFLAGS -g -Wall -Werror -Wno-uninitialized  -Wno-deprecated-declarations -Wformat -Wformat-security -O0"
 	fi
 else
     AC_DEFINE([NDEBUG],[],[No-debug Mode])

--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@ AC_ARG_WITH([gtk3],
 			  [with_gtk3=yes])
 
 if test "$with_gtk3" = "yes" ; then
-	pkg_modules="gtk+-3.0 >= 3.6.0"
+	pkg_modules="gtk+-3.0 >= 3.4.2"
 	AC_DEFINE([WITH_GTK3], [], [Gtk3 mode])
 else
 	pkg_modules="gtk+-2.0 >= 2.16.0"


### PR DESCRIPTION
Since travis servers only have gtk-3.0 3.4.2, have configure check
for the earlier version.  Seems to build okay.  Probably nice
to allow more people to compile the gtk3 version