### PR TITLE
PNMixer only supports ALSA, make it clear in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ a panel that supports applets, and therefore can't run a mixer applet.
 In particular it's been used quite a lot with fbpanel and tint2, but
 should run fine in any system tray.
 
+PNMixer is designed to work on systems that use ALSA for sound management.
+Any other sound driver like OSS or FFADO, or sound server like PulseAudio
+or Jackd, are currently not supported.
+
 PNMixer is a fork of [OBMixer](http://jpegserv.com/?page_id=282) with
 a number of additions.  These include:
 


### PR DESCRIPTION
Alright, let's be explicit about the fact that PNMixer only supports ALSA at the moment.

Does that look good to you ? I'm not a native english speaker, so maybe you guys have a better way to tell things.

I also thought that we could add a run-time check for pulseaudio, and issue a warning in case pulse is running. But the fact is that, I don't know the right to way to check that, except a DBus call, but that means adding a dependency to libdbus. However, thinking of it, PNMixer already depends on glib2, which provides dbus facilities. So I guess we already depend on DBus, don't we ? Well if you think it's a good idea I can add that, then we're ready for a great 0.6 release :)