### PR TITLE
Fix setting volume by small step

### DIFF
--- a/src/alsa.c
+++ b/src/alsa.c
@@ -44,7 +44,6 @@
 #include <string.h>
 
 #define MAX_LINEAR_DB_SCALE	24
-#define PLAYBACK 0
 
 static inline gboolean use_linear_dB_scale(long dBmin, long dBmax){
 	return dBmax - dBmin <= MAX_LINEAR_DB_SCALE * 100;
@@ -476,10 +475,11 @@ static int convert_prange(long val, long min, long max) {
  * Adjusts the current volume and sends a notification (if enabled).
  *
  * @param vol new volume value
+ * @param dir select direction
  * @param notify whether to send notification
  * @return 0 on success otherwise negative error code
  */
-int setvol(int vol, gboolean notify) {
+int setvol(int vol, int dir, gboolean notify) {
   long min = 0, max = 0, value;
   int cur_perc = getvol();
   double dvol = 0.01 * vol;
@@ -487,7 +487,7 @@ int setvol(int vol, gboolean notify) {
   int err = snd_mixer_selem_get_playback_dB_range(elem, &min, &max);
   if (err < 0 || min >= max || !normalize_vol()) {
     err = snd_mixer_selem_get_playback_volume_range(elem, &min, &max);
-    value = lrint_dir(dvol * (max - min), PLAYBACK) + min;
+    value = lrint_dir(dvol * (max - min), dir) + min;
     snd_mixer_selem_set_playback_volume_all(elem, value);
     if (enable_noti && notify && cur_perc != getvol())
       do_notify(getvol(),FALSE);
@@ -495,8 +495,8 @@ int setvol(int vol, gboolean notify) {
   }
 
   if (use_linear_dB_scale(min, max)) {
-    value = lrint_dir(dvol * (max - min), PLAYBACK) + min;
-    return snd_mixer_selem_set_playback_dB_all(elem, value, PLAYBACK);
+    value = lrint_dir(dvol * (max - min), dir) + min;
+    return snd_mixer_selem_set_playback_dB_all(elem, value, dir);
   }
 
   if (min != SND_CTL_TLV_DB_GAIN_MUTE) {
@@ -504,11 +504,11 @@ int setvol(int vol, gboolean notify) {
     dvol = dvol * (1 - min_norm) + min_norm;
   }
 
-  value = lrint_dir(6000.0 * log10(dvol), PLAYBACK) + max;
-  snd_mixer_selem_set_playback_dB_all(elem, value, PLAYBACK);
+  value = lrint_dir(6000.0 * log10(dvol), dir) + max;
+  snd_mixer_selem_set_playback_dB_all(elem, value, dir);
   if (enable_noti && notify && cur_perc != getvol())
     do_notify(getvol(),FALSE);
-  return snd_mixer_selem_set_playback_dB_all(elem, value, PLAYBACK); // intentionally set twice
+  return snd_mixer_selem_set_playback_dB_all(elem, value, dir); // intentionally set twice
 }
 
 /**

--- a/src/alsa.c
+++ b/src/alsa.c
@@ -475,7 +475,8 @@ static int convert_prange(long val, long min, long max) {
  * Adjusts the current volume and sends a notification (if enabled).
  *
  * @param vol new volume value
- * @param dir select direction
+ * @param dir select direction (-1 = accurate or first bellow, 0 = accurate,
+ * 1 = accurate or first above)
  * @param notify whether to send notification
  * @return 0 on success otherwise negative error code
  */

--- a/src/alsa.h
+++ b/src/alsa.h
@@ -41,7 +41,7 @@ struct acard {
 
 GSList* cards;
 
-int setvol(int vol,gboolean notify);
+int setvol(int vol, int dir, gboolean notify);
 void setmute(gboolean notify);
 int getvol();
 int ismuted();

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -86,7 +86,7 @@ gboolean vol_scroll_event(GtkRange     *range,
 
   volumeset = (int) value;
 
-  setvol(volumeset,popup_noti);
+  setvol(volumeset,0,popup_noti);
   if (get_mute_state(TRUE) == 0) {
     setmute(popup_noti);
     get_mute_state(TRUE);
@@ -109,9 +109,9 @@ gboolean on_scroll(GtkStatusIcon *status_icon,
 		gpointer user_data) {
   int cv = getvol();
   if (event->direction == GDK_SCROLL_UP) {
-    setvol(cv + scroll_step,mouse_noti);
+    setvol(cv + scroll_step,1,mouse_noti);
   } else if (event->direction == GDK_SCROLL_DOWN) {
-    setvol(cv - scroll_step,mouse_noti);
+    setvol(cv - scroll_step,-1,mouse_noti);
   }
 
   if (get_mute_state(TRUE) == 0) {

--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -96,10 +96,10 @@ static GdkFilterReturn key_filter(GdkXEvent *gdk_xevent,
     } else {
       int cv = getvol();
       if ((int)key == volUpKey && checkModKey(state, volUpMods)) {
-	setvol(cv+volStep,enable_noti&&hotkey_noti);
+	setvol(cv+volStep,1,enable_noti&&hotkey_noti);
       }
       else if ((int)key == volDownKey && checkModKey(state, volDownMods)) {
-	setvol(cv-volStep,enable_noti&&hotkey_noti);
+	setvol(cv-volStep,-1,enable_noti&&hotkey_noti);
       } 
       // just ignore unknown hotkeys
 


### PR DESCRIPTION
If volume change step is small (e.g. set to 1) it might not be possible to
set all values - driver restriction. This might lead to a behavior where
the volume can not be changed any more.

Changes made in this commit will prevent such a situation by allowing driver
to set first bellow or first above value according to the change direction.