### PR TITLE
Replace mute/unmute menu item with a checkbox

### DIFF
--- a/data/ui/popup_window-gtk2.glade
+++ b/data/ui/popup_window-gtk2.glade
@@ -101,7 +101,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkCheckButton" id="mute_check">
+              <object class="GtkCheckButton" id="mute_check_popup_window">
                 <property name="label" translatable="yes">Mute</property>
                 <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
@@ -109,7 +109,6 @@
                 <property name="receives_default">False</property>
                 <property name="border_width">8</property>
                 <property name="draw_indicator">True</property>
-                <signal name="pressed" handler="on_mute_clicked" swapped="no"/>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -156,16 +155,13 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkImageMenuItem" id="mute_item">
-                        <property name="label" translatable="yes">_Mute/Unmute</property>
+                      <object class="GtkCheckMenuItem" id="mute_check_popup_menu">
+                        <property name="label" translatable="yes">_Mute</property>
                         <property name="use_action_appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Mute/Unmute Volume</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image3</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="on_mute_clicked" swapped="no"/>
                       </object>
                     </child>
                     <child>

--- a/data/ui/popup_window-gtk3.glade
+++ b/data/ui/popup_window-gtk3.glade
@@ -67,7 +67,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkCheckButton" id="mute_check">
+          <object class="GtkCheckButton" id="mute_check_popup_window">
             <property name="label" translatable="yes">Mute</property>
             <property name="use_action_appearance">False</property>
             <property name="visible">True</property>
@@ -76,7 +76,6 @@
             <property name="halign">center</property>
             <property name="xalign">0.5</property>
             <property name="draw_indicator">True</property>
-            <signal name="pressed" handler="on_mute_clicked" swapped="no"/>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -117,16 +116,13 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkImageMenuItem" id="mute_item">
-                        <property name="label" translatable="yes">_Mute/Unmute</property>
+                      <object class="GtkCheckMenuItem" id="mute_check_popup_menu">
+                        <property name="label" translatable="yes">_Mute</property>
                         <property name="use_action_appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Mute/Unmute Volume</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image3</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="on_mute_clicked" swapped="no"/>
                       </object>
                     </child>
                     <child>

--- a/src/alsa.c
+++ b/src/alsa.c
@@ -241,7 +241,8 @@ alsa_cb(snd_mixer_elem_t *e, unsigned int mask)
 	if (mask & SND_CTL_EVENT_MASK_VALUE) {
 		int muted;
 		get_current_levels();
-		muted = get_mute_state(TRUE);
+		muted = ismuted();
+		on_volume_has_changed();
 		if (enable_noti && external_noti) {
 			int vol = getvol();
 			if (muted)

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -33,9 +33,9 @@ int volume;
 extern int volume;
 
 /**
- * Callback function when the mute_check (GtkCheckButton) in the
- * volume popup window received the pressed signal
- * or when the mute_item (GtkImageMenuItem) in the right-click
+ * Callback function when the mute_check_popup_window (GtkCheckButton) in the
+ * volume popup window received the pressed signal or
+ * when the mute_check_popup_menu (GtkCheckMenuItem) in the right-click
  * menu received the activate signal.
  *
  * @param button the object that received the signal
@@ -47,7 +47,7 @@ on_mute_clicked(GtkButton *button, GdkEvent *event, gpointer user_data)
 {
 
 	setmute(popup_noti);
-	get_mute_state(FALSE);
+	on_volume_has_changed();
 	return TRUE;
 }
 
@@ -87,10 +87,11 @@ vol_scroll_event(GtkRange *range, GtkScrollType scroll,
 	volumeset = (int) value;
 
 	setvol(volumeset, 0, popup_noti);
-	if (get_mute_state(TRUE) == 0) {
+	if (ismuted() == 0)
 		setmute(popup_noti);
-		get_mute_state(TRUE);
-	}
+
+	on_volume_has_changed();
+
 	return FALSE;
 }
 
@@ -115,12 +116,14 @@ on_scroll(GtkStatusIcon *status_icon, GdkEventScroll *event,
 		setvol(cv - scroll_step, -1, mouse_noti);
 	}
 
-	if (get_mute_state(TRUE) == 0) {
+	if (ismuted() == 0)
 		setmute(mouse_noti);
-		get_mute_state(TRUE);
-	}
+
 	// this will set the slider value
 	get_current_levels();
+
+	on_volume_has_changed();
+
 	return TRUE;
 }
 

--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -93,7 +93,7 @@ key_filter(GdkXEvent *gdk_xevent, GdkEvent *event, gpointer data)
 
 		if ((int) key == volMuteKey && checkModKey(state, volMuteMods)) {
 			setmute(enable_noti && hotkey_noti);
-			get_mute_state(TRUE);
+			on_volume_has_changed();
 			return GDK_FILTER_CONTINUE;
 		} else {
 			int cv = getvol();
@@ -104,8 +104,10 @@ key_filter(GdkXEvent *gdk_xevent, GdkEvent *event, gpointer data)
 			}
 			// just ignore unknown hotkeys
 
-			if (get_mute_state(TRUE) == 0)
+			if (ismuted() == 0)
 				setmute(enable_noti && hotkey_noti);
+
+			on_volume_has_changed();
 
 			// this will set the slider value
 			get_current_levels();

--- a/src/main.h
+++ b/src/main.h
@@ -28,7 +28,8 @@
 
 GtkWidget *popup_window;
 GtkWidget *vol_scale;
-GtkWidget *mute_check;
+GtkWidget *mute_check_popup_window;
+GtkWidget *mute_check_popup_menu;
 GtkAdjustment *vol_adjustment;
 
 void create_popups(void);
@@ -39,8 +40,9 @@ void do_alsa_reinit(void);
 void report_error(char *, ...);
 void warn_sound_conn_lost(void);
 void get_current_levels(void);
-int get_mute_state(gboolean);
-int update_mute_state(void);
+void update_tray_icon(void);
+void update_mute_checkboxes(void);
+void on_volume_has_changed(void);
 gboolean hide_me(GtkWidget *, GdkEvent *, gpointer);
 gint tray_icon_size(void);
 void set_vol_meter_color(gdouble nr, gdouble ng, gdouble nb);


### PR DESCRIPTION
This also removes get_mute_state() and substitutes it with
a bit more atomic and bug-free versions.

Fixes #99