### PR TITLE
Add a '--debug' option to display debug messages, wrt #102

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,35 +79,6 @@ if test "$with_libnotify" = "yes" || test "$HAVE_LIBN" = "1"; then
 fi
 
 # ======================================================= #
-#                  Debug compilation support              #
-# ======================================================= #
-AC_MSG_CHECKING([whether to build with debug information])
-AC_ARG_ENABLE([debug],
-              [AS_HELP_STRING([--enable-debug], [enable debug data generation (def=no)])],
-              [debugit="$enableval"],
-              [debugit=no])
-AC_MSG_RESULT([$debugit])
-
-AC_ARG_ENABLE([minimal-flags],
-              [AS_HELP_STRING([--enable-minimal-flags], [respect system CFLAGS (def=no)])],
-              [minimalflags="$enableval"],
-              [minimalflags=no])
-
-if test "$debugit" = "yes"; then
-	AC_DEFINE([DEBUG], [], [Debug Mode])
-	if test "$minimalflags" = "no"; then
-		CFLAGS="$CFLAGS -g -Wall -Werror -Wno-uninitialized  -Wno-deprecated-declarations -Wformat -Wformat-security -O0"
-	fi
-else
-	AC_DEFINE([NDEBUG], [], [No-debug Mode])
-	if test "$minimalflags" = "no"; then
-		CFLAGS="$CFLAGS -O2"
-	fi
-fi
-
-LDFLAGS="$LDFLAGS -rdynamic"
-
-# ======================================================= #
 #                  Check for modules                      #
 # ======================================================= #
 PKG_CHECK_MODULES(PACKAGE, [$pkg_modules])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -14,7 +14,8 @@ pnmixer_SOURCES = \
 	notify.c notify.h \
 	alsa.c alsa.h \
 	callbacks.c callbacks.h \
-	prefs.c prefs.h
+	prefs.c prefs.h \
+	debug.h
 
 pnmixer_LDADD = @PACKAGE_LIBS@ $(INTLLIBS)
 

--- a/src/alsa.c
+++ b/src/alsa.c
@@ -35,6 +35,7 @@
 
 #define _GNU_SOURCE
 #include "alsa.h"
+#include "debug.h"
 #include "main.h"
 #include "notify.h"
 #include "prefs.h"
@@ -138,19 +139,19 @@ get_cards(void)
 		cur_card->channels = get_channels(buf);
 		cards = g_slist_append(cards, cur_card);
 	}
-#ifdef DEBUG
-	GSList *tmp = cards;
-	if (tmp) {
-		printf("------ Card list ------\n");
-		while (tmp) {
-			struct acard *c = tmp->data;
-			printf("\t%s\t%s\t%s\n", c->dev, c->name,
-			       c->channels ? "" : "No chann");
-			tmp = tmp->next;
+	if (want_debug == TRUE) {
+		GSList *tmp = cards;
+		if (tmp) {
+			printf("------ Card list ------\n");
+			while (tmp) {
+				struct acard *c = tmp->data;
+				printf("\t%s\t%s\t%s\n", c->dev, c->name,
+					   c->channels ? "" : "No chann");
+				tmp = tmp->next;
+			}
+			printf("-----------------------\n");
 		}
-		printf("-----------------------\n");
 	}
-#endif
 }
 
 /**
@@ -435,18 +436,18 @@ get_channels(const char *card)
 		telem = snd_mixer_elem_next(telem);
 	}
 
-#ifdef DEBUG
-	GSList *tmp = channels;
-	if (tmp) {
-		printf("Card %s: available channels\n", card);
-		while (tmp) {
-			printf("\t%s\n", (char *) tmp->data);
-			tmp = tmp->next;
+	if (want_debug == TRUE) {
+		GSList *tmp = channels;
+		if (tmp) {
+			printf("Card %s: available channels\n", card);
+			while (tmp) {
+				printf("\t%s\n", (char *) tmp->data);
+				tmp = tmp->next;
+			}
+		} else {
+			printf("Card %s: no playable channels\n", card);
 		}
-	} else {
-		printf("Card %s: no playable channels\n", card);
 	}
-#endif
 
 	close_mixer(mixer, card);
 

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,0 +1,41 @@
+/* debug.h
+ * PNmixer is written by Nick Lanham, a fork of OBmixer
+ * which was programmed by Lee Ferrett, derived
+ * from the program "AbsVolume" by Paul Sherman
+ * This program is free software; you can redistribute
+ * it and/or modify it under the terms of the GNU General
+ * Public License v3. source code is available at
+ * <http://github.com/nicklan/pnmixer>
+ */
+
+/**
+ * @file debug.h
+ * Header providing macros and global variables for debugging purposes.
+ * If you need debugging in your .c file, include this header.
+ * @brief debugging header
+ */
+
+#ifndef DEBUG_H
+#define DEBUG_H
+
+#include <glib.h>
+
+
+/**
+ * Global variable to control whether we want debugging.
+ * This variable is initialized in main() and depends on the
+ * '--debug'/'-d' command line argument.
+ */
+gboolean want_debug;
+
+/**
+ * Macro to print verbose debug info in case we want debugging.
+ */
+#define DEBUG_PRINT(fmt, ...) \
+{ \
+	if (want_debug == TRUE) { \
+		printf(fmt"\n", ##__VA_ARGS__); \
+	} \
+}
+
+#endif				// DEBUG_H

--- a/src/main.c
+++ b/src/main.c
@@ -32,6 +32,7 @@
 #include <fcntl.h>
 #include <locale.h>
 #include "alsa.h"
+#include "debug.h"
 #include "callbacks.h"
 #include "main.h"
 #include "notify.h"
@@ -793,6 +794,10 @@ static GOptionEntry args[] = {
 		"version", 0, 0, G_OPTION_ARG_NONE, &version, "Show version and exit",
 		NULL
 	},
+	{
+		"debug", 'd', 0, G_OPTION_ARG_NONE, &want_debug, "Run in debug mode",
+		NULL
+	},
 	{NULL, 0, 0, 0, NULL, NULL, NULL}
 };
 
@@ -810,6 +815,7 @@ main(int argc, char *argv[])
 {
 	GError *error = NULL;
 	GOptionContext *context;
+	want_debug = FALSE;
 
 #ifdef ENABLE_NLS
 	bindtextdomain(GETTEXT_PACKAGE, PACKAGE_LOCALE_DIR);

--- a/src/main.h
+++ b/src/main.h
@@ -20,11 +20,6 @@
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
 
-#ifdef DEBUG
-#define DEBUG_PRINT(fmt, ...) printf(fmt"\n", ##__VA_ARGS__)
-#else
-#define DEBUG_PRINT(...)
-#endif
 
 GtkWidget *popup_window;
 GtkWidget *vol_scale;

--- a/src/support.c
+++ b/src/support.c
@@ -29,6 +29,7 @@
 
 #include <gtk/gtk.h>
 
+#include "debug.h"
 #include "main.h"
 #include "support.h"
 #include "prefs.h"


### PR DESCRIPTION
This introduces the global variable 'want_debug' and adjusts
the DEBUG_PRINT macro.

In order to use debugging in a file, one must include "debug.h".

The "Debug compilation" support section in configure.ac has been
removed, since it now only controls CFLAGS, which we can set
via the environment anyway.