### PR TITLE
Simplify icon theme foo

### DIFF
--- a/data/ui/prefs-gtk2.glade
+++ b/data/ui/prefs-gtk2.glade
@@ -277,7 +277,7 @@
     <property name="default_width">350</property>
     <property name="default_height">500</property>
     <property name="icon_name">preferences-system</property>
-    <signal name="key_press_event" handler="on_key_press" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_press" swapped="no"/>
     <child>
       <object class="GtkAlignment" id="alignment1">
         <property name="visible">True</property>
@@ -520,10 +520,12 @@
                             <property name="bottom_padding">5</property>
                             <property name="left_padding">12</property>
                             <child>
-                              <object class="GtkComboBoxText" id="icon_theme_combo">
+                              <object class="GtkCheckButton" id="system_theme">
+                                <property name="label" translatable="yes">Use system theme</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-				<property name="entry_text_column">0</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="draw_indicator">True</property>
                               </object>
                             </child>
                           </object>
@@ -606,7 +608,7 @@
                                   <object class="GtkComboBoxText" id="card_combo">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-				    <property name="entry_text_column">0</property>
+                                    <property name="entry_text_column">0</property>
                                     <signal name="changed" handler="on_card_changed" swapped="no"/>
                                   </object>
                                   <packing>
@@ -619,7 +621,7 @@
                                   <object class="GtkComboBoxText" id="chan_combo">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-				    <property name="entry_text_column">0</property>
+                                    <property name="entry_text_column">0</property>
                                   </object>
                                   <packing>
                                     <property name="left_attach">1</property>

--- a/data/ui/prefs-gtk3.glade
+++ b/data/ui/prefs-gtk3.glade
@@ -123,8 +123,8 @@
                   <object class="GtkLabel" id="label26">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
                     <property name="label" translatable="yes">Notify for volume changes from:</property>
+                    <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -351,8 +351,8 @@
                                   <object class="GtkLabel" id="vol_pos_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Volume Text Position:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -443,8 +443,8 @@
                                   <object class="GtkLabel" id="vol_meter_pos_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Volume Meter Offset:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -456,8 +456,8 @@
                                   <object class="GtkLabel" id="vol_meter_color_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Volume Meter Color:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -536,9 +536,14 @@
                             <property name="bottom_padding">5</property>
                             <property name="left_padding">12</property>
                             <child>
-                              <object class="GtkComboBoxText" id="icon_theme_combo">
+                              <object class="GtkCheckButton" id="system_theme">
+                                <property name="label" translatable="yes">Use system theme</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="xalign">0</property>
+                                <property name="draw_indicator">True</property>
                               </object>
                             </child>
                           </object>
@@ -601,8 +606,8 @@
                                   <object class="GtkLabel" id="label10">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Card:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="y_options">GTK_EXPAND</property>
@@ -612,8 +617,8 @@
                                   <object class="GtkLabel" id="label11">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Channel:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -669,8 +674,8 @@
                                   <object class="GtkLabel" id="label23">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.15999999642372131</property>
                                     <property name="label" translatable="yes">Normalize Volume:</property>
+                                    <property name="xalign">0.15999999642372131</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -784,8 +789,8 @@
                                   <object class="GtkLabel" id="label14">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Mouse Scroll Step:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="y_options">GTK_EXPAND</property>
@@ -795,8 +800,8 @@
                                   <object class="GtkLabel" id="label15">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Middle Click Action:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -808,8 +813,8 @@
                                   <object class="GtkLabel" id="custom_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Custom Command:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -951,8 +956,8 @@
                                   <object class="GtkLabel" id="hotkey_vol_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">HotKey Volume Step:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -1021,8 +1026,8 @@
                                   <object class="GtkLabel" id="label7">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Mute/Unmute:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -1033,8 +1038,8 @@
                                   <object class="GtkLabel" id="label8">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Volume Up:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -1045,8 +1050,8 @@
                                   <object class="GtkLabel" id="label18">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Volume Down:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">3</property>
@@ -1270,6 +1275,34 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area3">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label">gtk-cancel</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkHBox" id="hbox1">
             <property name="visible">True</property>
@@ -1312,8 +1345,8 @@
                   <object class="GtkLabel" id="hotkey_reset_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="yalign">0.10000000149011612</property>
                     <property name="label" translatable="yes">(press &lt;Ctrl&gt;C to reset)</property>
+                    <property name="yalign">0.10000000149011612</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -1350,8 +1383,8 @@
           <object class="GtkLabel" id="def_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="yalign">0.89999997615814209</property>
             <property name="label" translatable="yes">Press new HotKey for:</property>
+            <property name="yalign">0.89999997615814209</property>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -1359,40 +1392,12 @@
             <property name="position">2</property>
           </packing>
         </child>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area3">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="button1">
-                <property name="label">gtk-cancel</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkLabel" id="hotkey_key_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="yalign">0.10000000149011612</property>
             <property name="label" translatable="yes">(Unknown)</property>
+            <property name="yalign">0.10000000149011612</property>
             <attributes>
               <attribute name="weight" value="bold"/>
             </attributes>

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -234,18 +234,10 @@ on_ok_button_clicked(G_GNUC_UNUSED GtkButton *button, PrefsData *data)
 	g_free(chan);
 
 	// icon theme
-	GtkWidget *icon_combo = data->icon_theme_combo;
-	idx = gtk_combo_box_get_active(GTK_COMBO_BOX(icon_combo));
-	if (idx == 0) {		// internal theme
-		g_key_file_remove_key(keyFile, "PNMixer", "IconTheme", NULL);
-	} else {
-		gchar *theme_name =
-			gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(icon_combo));
-		if (theme_name) {
-			g_key_file_set_string(keyFile, "PNMixer", "IconTheme", theme_name);
-			g_free(theme_name);
-		}
-	}
+	GtkWidget *system_theme = data->system_theme;
+	active = gtk_toggle_button_get_active(
+			GTK_TOGGLE_BUTTON(system_theme));
+	g_key_file_set_boolean(keyFile, "PNMixer", "SystemTheme", active);
 
 	// volume control command
 	GtkWidget *ve = data->vol_control_entry;

--- a/src/main.c
+++ b/src/main.c
@@ -708,7 +708,8 @@ update_status_icons(void)
 	int size = tray_icon_size();
 	for (i = 0; i < N_VOLUME_ICONS; i++)
 		old_icons[i] = status_icons[i];
-	if (g_key_file_has_key(keyFile, "PNMixer", "IconTheme", NULL)) {
+	if (g_key_file_get_boolean(keyFile, "PNMixer", "SystemTheme", NULL)
+			== TRUE) {
 		status_icons[VOLUME_MUTED] = get_stock_pixbuf("audio-volume-muted",
 					     size);
 		status_icons[VOLUME_OFF] = get_stock_pixbuf("audio-volume-off", size);

--- a/src/support.c
+++ b/src/support.c
@@ -154,7 +154,7 @@ get_stock_pixbuf(const char *filename, gint size)
 	GError *err = NULL;
 	GdkPixbuf *return_buf = NULL;
 	if (icon_theme == NULL)
-		get_icon_theme();
+		icon_theme = gtk_icon_theme_get_default();
 	return_buf = gtk_icon_theme_load_icon(icon_theme, filename,
 					      size, 0, &err);
 	if (err != NULL) {

--- a/src/support.h
+++ b/src/support.h
@@ -66,7 +66,7 @@ typedef struct {
 	GtkWidget *custom_entry;
 	GtkWidget *vol_text_check;
 	GtkWidget *draw_vol_check;
-	GtkWidget *icon_theme_combo;
+	GtkWidget *system_theme;
 	GtkWidget *vol_control_entry;
 	GtkWidget *scroll_step_spin;
 	GtkWidget *middle_click_combo;


### PR DESCRIPTION
We removed the ability to choose a particular icon theme, since that
doesn't seem like a useful use case. The icon theme is generally
set globally, not per-application. The user can still use the pnmixer
icons, which is also default.

Fixes #95