### PR TITLE
Deprecation warnings

### DIFF
--- a/data/ui/popup_window-gtk3.glade
+++ b/data/ui/popup_window-gtk3.glade
@@ -2,25 +2,6 @@
 <!-- Generated with glade 3.18.3 -->
 <interface>
   <requires lib="gtk+" version="3.6"/>
-  <object class="GtkImage" id="image3">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">audio-volume-muted</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image4">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-execute</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image5">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="ypad">2</property>
-    <property name="stock">gtk-refresh</property>
-    <property name="icon_size">1</property>
-  </object>
   <object class="GtkAdjustment" id="vol_scale_adjustment">
     <property name="upper">100</property>
     <property name="step_increment">1</property>
@@ -42,8 +23,8 @@
       <object class="GtkBox" id="vbox1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">8</property>
-        <property name="margin_right">8</property>
+        <property name="margin_start">8</property>
+        <property name="margin_end">8</property>
         <property name="margin_top">8</property>
         <property name="margin_bottom">8</property>
         <property name="orientation">vertical</property>
@@ -74,7 +55,6 @@
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
             <property name="halign">center</property>
-            <property name="xalign">0.5</property>
             <property name="draw_indicator">True</property>
           </object>
           <packing>
@@ -117,62 +97,164 @@
                     <property name="can_focus">False</property>
                     <child>
                       <object class="GtkCheckMenuItem" id="mute_check_popup_menu">
-                        <property name="label" translatable="yes">_Mute</property>
                         <property name="use_action_appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Mute/Unmute Volume</property>
+                        <property name="label" translatable="yes">Mute</property>
                         <property name="use_underline">True</property>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="volcontrol_item">
-                        <property name="label" translatable="yes">_Volume Control</property>
+                      <object class="GtkMenuItem" id="volcontrol_item">
                         <property name="use_action_appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Open Volume Control</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image4</property>
-                        <property name="use_stock">False</property>
                         <signal name="activate" handler="on_mixer" swapped="no"/>
+                        <child>
+                          <object class="GtkBox" id="box1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkImage" id="image1">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">system-run</property>
+                                <property name="icon_size">1</property>
+                              </object>
+                              <packing>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAccelLabel" id="accellabel1">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="margin_start">4</property>
+                                <property name="margin_end">8</property>
+                                <property name="label" translatable="yes">Volume Control</property>
+                              </object>
+                              <packing>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="prefs_item">
-                        <property name="label">gtk-preferences</property>
+                      <object class="GtkMenuItem" id="prefs_item">
                         <property name="use_action_appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Preferences</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
                         <signal name="activate" handler="do_prefs" swapped="no"/>
+                        <child>
+                          <object class="GtkBox" id="box2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkImage" id="image2">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">preferences-desktop</property>
+                                <property name="icon_size">1</property>
+                              </object>
+                              <packing>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAccelLabel" id="accellabel2">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="margin_start">4</property>
+                                <property name="margin_end">8</property>
+                                <property name="label" translatable="yes">Preferences</property>
+                              </object>
+                              <packing>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="reload_item">
-                        <property name="label" translatable="yes">_Reload Alsa</property>
+                      <object class="GtkMenuItem" id="reload_item">
                         <property name="use_action_appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Reload Alsa</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image5</property>
-                        <property name="use_stock">False</property>
                         <signal name="activate" handler="do_alsa_reinit" swapped="no"/>
+                        <child>
+                          <object class="GtkBox" id="box3">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkImage" id="image3">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">gtk-refresh</property>
+                                <property name="icon_size">1</property>
+                              </object>
+                              <packing>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAccelLabel" id="accellabel3">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="margin_start">4</property>
+                                <property name="margin_end">8</property>
+                                <property name="label" translatable="yes">Reload Alsa</property>
+                              </object>
+                              <packing>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="about_item">
-                        <property name="label">gtk-about</property>
+                      <object class="GtkMenuItem" id="about_item">
                         <property name="use_action_appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">About</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
                         <signal name="activate" handler="create_about" swapped="no"/>
+                        <child>
+                          <object class="GtkBox" id="box4">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkImage" id="image4">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">help-about</property>
+                                <property name="icon_size">1</property>
+                              </object>
+                              <packing>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAccelLabel" id="accellabel4">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="margin_start">4</property>
+                                <property name="margin_end">8</property>
+                                <property name="label" translatable="yes">About</property>
+                              </object>
+                              <packing>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
                       </object>
                     </child>
                     <child>
@@ -183,15 +265,41 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="quit_item">
-                        <property name="label">gtk-quit</property>
+                      <object class="GtkMenuItem" id="quit_item">
                         <property name="use_action_appearance">False</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Quit</property>
-                        <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
                         <signal name="activate" handler="gtk_main_quit" swapped="no"/>
+                        <child>
+                          <object class="GtkBox" id="box5">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkImage" id="image5">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">gtk-quit</property>
+                                <property name="icon_size">1</property>
+                              </object>
+                              <packing>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkAccelLabel" id="accellabel5">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="margin_start">4</property>
+                                <property name="margin_end">8</property>
+                                <property name="label" translatable="yes">Quit</property>
+                              </object>
+                              <packing>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/data/ui/prefs-gtk2.glade
+++ b/data/ui/prefs-gtk2.glade
@@ -277,7 +277,7 @@
     <property name="default_width">350</property>
     <property name="default_height">500</property>
     <property name="icon_name">preferences-system</property>
-    <signal name="key_press_event" handler="on_key_press" swapped="no"/>
+    <signal name="key-press-event" handler="on_key_press" swapped="no"/>
     <child>
       <object class="GtkAlignment" id="alignment1">
         <property name="visible">True</property>
@@ -520,10 +520,12 @@
                             <property name="bottom_padding">5</property>
                             <property name="left_padding">12</property>
                             <child>
-                              <object class="GtkComboBoxText" id="icon_theme_combo">
+                              <object class="GtkCheckButton" id="system_theme">
+                                <property name="label" translatable="yes">Use system theme</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-				<property name="entry_text_column">0</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="draw_indicator">True</property>
                               </object>
                             </child>
                           </object>
@@ -606,7 +608,7 @@
                                   <object class="GtkComboBoxText" id="card_combo">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-				    <property name="entry_text_column">0</property>
+                                    <property name="entry_text_column">0</property>
                                     <signal name="changed" handler="on_card_changed" swapped="no"/>
                                   </object>
                                   <packing>
@@ -619,7 +621,7 @@
                                   <object class="GtkComboBoxText" id="chan_combo">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-				    <property name="entry_text_column">0</property>
+                                    <property name="entry_text_column">0</property>
                                   </object>
                                   <packing>
                                     <property name="left_attach">1</property>

--- a/data/ui/prefs-gtk3.glade
+++ b/data/ui/prefs-gtk3.glade
@@ -49,15 +49,14 @@
       <object class="GtkFrame" id="frame9">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="margin_left">5</property>
-        <property name="margin_right">5</property>
-        <property name="label_xalign">0</property>
+        <property name="margin_start">5</property>
+        <property name="margin_end">5</property>
         <property name="shadow_type">none</property>
         <child>
           <object class="GtkAlignment" id="alignment10">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="left_padding">12</property>
+            <property name="margin_start">12</property>
             <child>
               <object class="GtkVBox" id="vbox7">
                 <property name="visible">True</property>
@@ -70,7 +69,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="xalign">0.5</property>
+                    <property name="halign">0.5</property>
                     <property name="draw_indicator">True</property>
                     <signal name="toggled" handler="on_notification_toggle" swapped="no"/>
                   </object>
@@ -124,7 +123,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Notify for volume changes from:</property>
-                    <property name="xalign">0</property>
+                    <property name="halign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -140,7 +139,7 @@
                   <object class="GtkAlignment" id="alignment11">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="left_padding">10</property>
+                    <property name="margin_start">10</property>
                     <child>
                       <object class="GtkCheckButton" id="hotkey_noti_check">
                         <property name="label" translatable="yes">HotKeys</property>
@@ -148,7 +147,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="xalign">0.5</property>
+                        <property name="halign">0.5</property>
                         <property name="draw_indicator">True</property>
                       </object>
                     </child>
@@ -163,7 +162,7 @@
                   <object class="GtkAlignment" id="alignment12">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="left_padding">10</property>
+                    <property name="margin_start">10</property>
                     <child>
                       <object class="GtkCheckButton" id="mouse_noti_check">
                         <property name="label" translatable="yes">Mouse Scroll</property>
@@ -171,7 +170,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="xalign">0.5</property>
+                        <property name="halign">0.5</property>
                         <property name="draw_indicator">True</property>
                       </object>
                     </child>
@@ -186,7 +185,7 @@
                   <object class="GtkAlignment" id="alignment13">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="left_padding">10</property>
+                    <property name="margin_start">10</property>
                     <child>
                       <object class="GtkCheckButton" id="popup_noti_check">
                         <property name="label" translatable="yes">Adjustment in Popup Window</property>
@@ -194,7 +193,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="xalign">0.5</property>
+                        <property name="halign">0.5</property>
                         <property name="draw_indicator">True</property>
                       </object>
                     </child>
@@ -209,7 +208,7 @@
                   <object class="GtkAlignment" id="alignment14">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="left_padding">10</property>
+                    <property name="margin_start">10</property>
                     <child>
                       <object class="GtkCheckButton" id="external_noti_check">
                         <property name="label" translatable="yes">External Change</property>
@@ -217,7 +216,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="xalign">0.5</property>
+                        <property name="halign">0.5</property>
                         <property name="draw_indicator">True</property>
                       </object>
                     </child>
@@ -291,10 +290,10 @@
       <object class="GtkAlignment" id="alignment1">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="top_padding">5</property>
-        <property name="bottom_padding">5</property>
-        <property name="left_padding">5</property>
-        <property name="right_padding">5</property>
+        <property name="margin_top">5</property>
+        <property name="margin_bottom">5</property>
+        <property name="margin_start">5</property>
+        <property name="margin_end">5</property>
         <child>
           <object class="GtkVBox" id="vbox1">
             <property name="visible">True</property>
@@ -314,16 +313,15 @@
                       <object class="GtkFrame" id="frame1">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
-                        <property name="label_xalign">0</property>
+                        <property name="margin_start">5</property>
+                        <property name="margin_end">5</property>
                         <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment2">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="top_padding">10</property>
-                            <property name="left_padding">12</property>
+                            <property name="margin_top">10</property>
+                            <property name="margin_start">12</property>
                             <child>
                               <object class="GtkTable" id="table1">
                                 <property name="visible">True</property>
@@ -338,7 +336,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
-                                    <property name="xalign">0.5</property>
+                                    <property name="halign">0.5</property>
                                     <property name="draw_indicator">True</property>
                                     <signal name="toggled" handler="on_vol_text_toggle" swapped="no"/>
                                   </object>
@@ -352,7 +350,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Volume Text Position:</property>
-                                    <property name="xalign">0.079999998211860657</property>
+                                    <property name="halign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -405,16 +403,15 @@
                       <object class="GtkFrame" id="frame2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
-                        <property name="label_xalign">0</property>
+                        <property name="margin_start">5</property>
+                        <property name="margin_end">5</property>
                         <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment3">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="top_padding">10</property>
-                            <property name="left_padding">12</property>
+                            <property name="margin_top">10</property>
+                            <property name="margin_start">12</property>
                             <child>
                               <object class="GtkTable" id="table2">
                                 <property name="visible">True</property>
@@ -430,7 +427,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
-                                    <property name="xalign">0.5</property>
+                                    <property name="halign">0.5</property>
                                     <property name="draw_indicator">True</property>
                                     <signal name="toggled" handler="on_draw_vol_toggle" swapped="no"/>
                                   </object>
@@ -444,7 +441,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Volume Meter Offset:</property>
-                                    <property name="xalign">0.079999998211860657</property>
+                                    <property name="halign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -457,7 +454,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Volume Meter Color:</property>
-                                    <property name="xalign">0.079999998211860657</property>
+                                    <property name="halign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -490,7 +487,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">True</property>
-                                    <property name="color">#000000000000</property>
+                                    <property name="rgba">rgb(0,0,0)</property>
                                   </object>
                                   <packing>
                                     <property name="left_attach">1</property>
@@ -524,17 +521,16 @@
                       <object class="GtkFrame" id="frame6">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
-                        <property name="label_xalign">0</property>
+                        <property name="margin_start">5</property>
+                        <property name="margin_end">5</property>
                         <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment7">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="top_padding">5</property>
-                            <property name="bottom_padding">5</property>
-                            <property name="left_padding">12</property>
+                            <property name="margin_top">5</property>
+                            <property name="margin_bottom">5</property>
+                            <property name="margin_start">12</property>
                             <child>
                               <object class="GtkCheckButton" id="system_theme">
                                 <property name="label" translatable="yes">Use system theme</property>
@@ -542,7 +538,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
-                                <property name="xalign">0</property>
+                                <property name="halign">0</property>
                                 <property name="draw_indicator">True</property>
                               </object>
                             </child>
@@ -584,16 +580,15 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="valign">start</property>
-                        <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
+                        <property name="margin_start">5</property>
+                        <property name="margin_end">5</property>
                         <property name="vexpand">False</property>
-                        <property name="label_xalign">0</property>
                         <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment4">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="margin_start">12</property>
                             <child>
                               <object class="GtkTable" id="table3">
                                 <property name="visible">True</property>
@@ -607,7 +602,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Card:</property>
-                                    <property name="xalign">0.079999998211860657</property>
+                                    <property name="halign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="y_options">GTK_EXPAND</property>
@@ -618,7 +613,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Channel:</property>
-                                    <property name="xalign">0.079999998211860657</property>
+                                    <property name="halign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -657,7 +652,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
-                                    <property name="xalign">0</property>
+                                    <property name="halign">0</property>
                                     <property name="draw_indicator">True</property>
                                     <child>
                                       <placeholder/>
@@ -675,7 +670,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Normalize Volume:</property>
-                                    <property name="xalign">0.15999999642372131</property>
+                                    <property name="halign">0.15999999642372131</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -727,16 +722,15 @@
                       <object class="GtkFrame" id="frame4">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
-                        <property name="label_xalign">0</property>
+                        <property name="margin_start">5</property>
+                        <property name="margin_end">5</property>
                         <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment5">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="top_padding">10</property>
-                            <property name="left_padding">12</property>
+                            <property name="margin_top">10</property>
+                            <property name="margin_start">12</property>
                             <child>
                               <object class="GtkEntry" id="vol_control_entry">
                                 <property name="visible">True</property>
@@ -768,15 +762,14 @@
                       <object class="GtkFrame" id="frame5">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
-                        <property name="label_xalign">0</property>
+                        <property name="margin_start">5</property>
+                        <property name="margin_end">5</property>
                         <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment6">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="left_padding">12</property>
+                            <property name="margin_start">12</property>
                             <child>
                               <object class="GtkTable" id="table4">
                                 <property name="visible">True</property>
@@ -790,7 +783,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Mouse Scroll Step:</property>
-                                    <property name="xalign">0.079999998211860657</property>
+                                    <property name="halign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="y_options">GTK_EXPAND</property>
@@ -801,7 +794,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Middle Click Action:</property>
-                                    <property name="xalign">0.079999998211860657</property>
+                                    <property name="halign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -814,7 +807,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Custom Command:</property>
-                                    <property name="xalign">0.079999998211860657</property>
+                                    <property name="halign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -919,16 +912,15 @@
                       <object class="GtkFrame" id="frame8">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
-                        <property name="label_xalign">0</property>
+                        <property name="margin_start">5</property>
+                        <property name="margin_end">5</property>
                         <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment9">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="top_padding">8</property>
-                            <property name="left_padding">12</property>
+                            <property name="margin_top">8</property>
+                            <property name="margin_start">12</property>
                             <child>
                               <object class="GtkTable" id="table6">
                                 <property name="visible">True</property>
@@ -944,7 +936,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="receives_default">False</property>
-                                    <property name="xalign">0.5</property>
+                                    <property name="halign">0.5</property>
                                     <property name="draw_indicator">True</property>
                                     <signal name="toggled" handler="on_hotkey_toggle" swapped="no"/>
                                   </object>
@@ -957,7 +949,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">HotKey Volume Step:</property>
-                                    <property name="xalign">0.079999998211860657</property>
+                                    <property name="halign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -1004,16 +996,15 @@
                       <object class="GtkFrame" id="frame7">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="margin_left">5</property>
-                        <property name="margin_right">5</property>
-                        <property name="label_xalign">0</property>
+                        <property name="margin_start">5</property>
+                        <property name="margin_end">5</property>
                         <property name="shadow_type">none</property>
                         <child>
                           <object class="GtkAlignment" id="alignment8">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="top_padding">10</property>
-                            <property name="left_padding">12</property>
+                            <property name="margin_top">10</property>
+                            <property name="margin_start">12</property>
                             <child>
                               <object class="GtkTable" id="table5">
                                 <property name="visible">True</property>
@@ -1027,7 +1018,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Mute/Unmute:</property>
-                                    <property name="xalign">0.079999998211860657</property>
+                                    <property name="halign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -1039,7 +1030,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Volume Up:</property>
-                                    <property name="xalign">0.079999998211860657</property>
+                                    <property name="halign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -1051,7 +1042,7 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="label" translatable="yes">Volume Down:</property>
-                                    <property name="xalign">0.079999998211860657</property>
+                                    <property name="halign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">3</property>
@@ -1208,20 +1199,50 @@
               </packing>
             </child>
             <child>
-              <object class="GtkHButtonBox" id="hbuttonbox1">
+             <object class="GtkHButtonBox" id="hbuttonbox1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="spacing">10</property>
                 <property name="layout_style">end</property>
                 <child>
                   <object class="GtkButton" id="cancel_button">
-                    <property name="label">gtk-cancel</property>
                     <property name="use_action_appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
+                    <property name="valign">0.47999998927116394</property>
                     <signal name="clicked" handler="on_cancel_button_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkBox" id="box2">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkImage" id="image2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">gtk-cancel</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label27">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_start">8</property>
+                            <property name="label" translatable="yes">Cancel</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -1231,21 +1252,45 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="ok_button">
-                    <property name="label">gtk-ok</property>
                     <property name="use_action_appearance">False</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="use_stock">True</property>
                     <signal name="clicked" handler="on_ok_button_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
+                    <child>
+                      <object class="GtkBox" id="box3">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkImage" id="image3">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">gtk-ok</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label29">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_start">8</property>
+                            <property name="label" translatable="yes">Ok</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+				  </object>
+				</child>
+			  </object>
               <packing>
                 <property name="expand">True</property>
                 <property name="fill">True</property>
@@ -1282,12 +1327,41 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button1">
-                <property name="label">gtk-cancel</property>
                 <property name="use_action_appearance">False</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <child>
+                  <object class="GtkBox" id="box4">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkImage" id="image4">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">gtk-cancel</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label30">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_start">8</property>
+                        <property name="label" translatable="yes">Cancel</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -1311,7 +1385,8 @@
               <object class="GtkImage" id="image1">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="xpad">10</property>
+                <property name="margin_start">10</property>
+                <property name="margin_end">10</property>
                 <property name="pixel_size">57</property>
                 <property name="icon_name">input-keyboard</property>
                 <property name="icon_size">3</property>
@@ -1346,7 +1421,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="label" translatable="yes">(press &lt;Ctrl&gt;C to reset)</property>
-                    <property name="yalign">0.10000000149011612</property>
+                    <property name="valign">0.10000000149011612</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -1384,7 +1459,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="label" translatable="yes">Press new HotKey for:</property>
-            <property name="yalign">0.89999997615814209</property>
+            <property name="valign">0.89999997615814209</property>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -1397,7 +1472,7 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="label" translatable="yes">(Unknown)</property>
-            <property name="yalign">0.10000000149011612</property>
+            <property name="valign">0.10000000149011612</property>
             <attributes>
               <attribute name="weight" value="bold"/>
             </attributes>

--- a/data/ui/prefs-gtk3.glade
+++ b/data/ui/prefs-gtk3.glade
@@ -123,8 +123,8 @@
                   <object class="GtkLabel" id="label26">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
                     <property name="label" translatable="yes">Notify for volume changes from:</property>
+                    <property name="xalign">0</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
                     </attributes>
@@ -351,8 +351,8 @@
                                   <object class="GtkLabel" id="vol_pos_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Volume Text Position:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -443,8 +443,8 @@
                                   <object class="GtkLabel" id="vol_meter_pos_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Volume Meter Offset:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -456,8 +456,8 @@
                                   <object class="GtkLabel" id="vol_meter_color_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Volume Meter Color:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -536,9 +536,14 @@
                             <property name="bottom_padding">5</property>
                             <property name="left_padding">12</property>
                             <child>
-                              <object class="GtkComboBoxText" id="icon_theme_combo">
+                              <object class="GtkCheckButton" id="system_theme">
+                                <property name="label" translatable="yes">Use system theme</property>
+                                <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="xalign">0</property>
+                                <property name="draw_indicator">True</property>
                               </object>
                             </child>
                           </object>
@@ -601,8 +606,8 @@
                                   <object class="GtkLabel" id="label10">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Card:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="y_options">GTK_EXPAND</property>
@@ -612,8 +617,8 @@
                                   <object class="GtkLabel" id="label11">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Channel:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -669,8 +674,8 @@
                                   <object class="GtkLabel" id="label23">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.15999999642372131</property>
                                     <property name="label" translatable="yes">Normalize Volume:</property>
+                                    <property name="xalign">0.15999999642372131</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -784,8 +789,8 @@
                                   <object class="GtkLabel" id="label14">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Mouse Scroll Step:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="y_options">GTK_EXPAND</property>
@@ -795,8 +800,8 @@
                                   <object class="GtkLabel" id="label15">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Middle Click Action:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -808,8 +813,8 @@
                                   <object class="GtkLabel" id="custom_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Custom Command:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -951,8 +956,8 @@
                                   <object class="GtkLabel" id="hotkey_vol_label">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">HotKey Volume Step:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -1021,8 +1026,8 @@
                                   <object class="GtkLabel" id="label7">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Mute/Unmute:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">1</property>
@@ -1033,8 +1038,8 @@
                                   <object class="GtkLabel" id="label8">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Volume Up:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">2</property>
@@ -1045,8 +1050,8 @@
                                   <object class="GtkLabel" id="label18">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xalign">0.079999998211860657</property>
                                     <property name="label" translatable="yes">Volume Down:</property>
+                                    <property name="xalign">0.079999998211860657</property>
                                   </object>
                                   <packing>
                                     <property name="top_attach">3</property>
@@ -1270,6 +1275,34 @@
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area3">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="button1">
+                <property name="label">gtk-cancel</property>
+                <property name="use_action_appearance">False</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
         <child>
           <object class="GtkHBox" id="hbox1">
             <property name="visible">True</property>
@@ -1312,8 +1345,8 @@
                   <object class="GtkLabel" id="hotkey_reset_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="yalign">0.10000000149011612</property>
                     <property name="label" translatable="yes">(press &lt;Ctrl&gt;C to reset)</property>
+                    <property name="yalign">0.10000000149011612</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>
@@ -1350,8 +1383,8 @@
           <object class="GtkLabel" id="def_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="yalign">0.89999997615814209</property>
             <property name="label" translatable="yes">Press new HotKey for:</property>
+            <property name="yalign">0.89999997615814209</property>
           </object>
           <packing>
             <property name="expand">True</property>
@@ -1359,40 +1392,12 @@
             <property name="position">2</property>
           </packing>
         </child>
-        <child internal-child="action_area">
-          <object class="GtkButtonBox" id="dialog-action_area3">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
-            <child>
-              <object class="GtkButton" id="button1">
-                <property name="label">gtk-cancel</property>
-                <property name="use_action_appearance">False</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="pack_type">end</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkLabel" id="hotkey_key_label">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="yalign">0.10000000149011612</property>
             <property name="label" translatable="yes">(Unknown)</property>
+            <property name="yalign">0.10000000149011612</property>
             <attributes>
               <attribute name="weight" value="bold"/>
             </attributes>

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -234,18 +234,10 @@ on_ok_button_clicked(G_GNUC_UNUSED GtkButton *button, PrefsData *data)
 	g_free(chan);
 
 	// icon theme
-	GtkWidget *icon_combo = data->icon_theme_combo;
-	idx = gtk_combo_box_get_active(GTK_COMBO_BOX(icon_combo));
-	if (idx == 0) {		// internal theme
-		g_key_file_remove_key(keyFile, "PNMixer", "IconTheme", NULL);
-	} else {
-		gchar *theme_name =
-			gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(icon_combo));
-		if (theme_name) {
-			g_key_file_set_string(keyFile, "PNMixer", "IconTheme", theme_name);
-			g_free(theme_name);
-		}
-	}
+	GtkWidget *system_theme = data->system_theme;
+	active = gtk_toggle_button_get_active(
+			GTK_TOGGLE_BUTTON(system_theme));
+	g_key_file_set_boolean(keyFile, "PNMixer", "SystemTheme", active);
 
 	// volume control command
 	GtkWidget *ve = data->vol_control_entry;

--- a/src/main.c
+++ b/src/main.c
@@ -708,7 +708,8 @@ update_status_icons(void)
 	int size = tray_icon_size();
 	for (i = 0; i < N_VOLUME_ICONS; i++)
 		old_icons[i] = status_icons[i];
-	if (g_key_file_has_key(keyFile, "PNMixer", "IconTheme", NULL)) {
+	if (g_key_file_get_boolean(keyFile, "PNMixer", "SystemTheme", NULL)
+			== TRUE) {
 		status_icons[VOLUME_MUTED] = get_stock_pixbuf("audio-volume-muted",
 					     size);
 		status_icons[VOLUME_OFF] = get_stock_pixbuf("audio-volume-off", size);

--- a/src/support.c
+++ b/src/support.c
@@ -154,7 +154,7 @@ get_stock_pixbuf(const char *filename, gint size)
 	GError *err = NULL;
 	GdkPixbuf *return_buf = NULL;
 	if (icon_theme == NULL)
-		get_icon_theme();
+		icon_theme = gtk_icon_theme_get_default();
 	return_buf = gtk_icon_theme_load_icon(icon_theme, filename,
 					      size, 0, &err);
 	if (err != NULL) {

--- a/src/support.h
+++ b/src/support.h
@@ -66,7 +66,7 @@ typedef struct {
 	GtkWidget *custom_entry;
 	GtkWidget *vol_text_check;
 	GtkWidget *draw_vol_check;
-	GtkWidget *icon_theme_combo;
+	GtkWidget *system_theme;
 	GtkWidget *vol_control_entry;
 	GtkWidget *scroll_step_spin;
 	GtkWidget *middle_click_combo;


### PR DESCRIPTION
Fix deprecation warnings

This will probably break using glade, since some of the changes
don't seem to be supported by the glade editor.

Additionally, the GtkMenuItems in the right-click menu of the tray icon
have weird leading spaces after the conversion from GtkImageMenuItem.
I don't yet know how to fix these.

Don't merge this yet, it needs still some work.