### PR TITLE
Prefs rework

### DIFF
--- a/src/alsa.c
+++ b/src/alsa.c
@@ -638,9 +638,10 @@ setvol(int vol, int dir, gboolean notify)
 	long min = 0, max = 0, value;
 	int cur_perc = getvol();
 	double dvol = 0.01 * vol;
+	gboolean normalize = prefs_get_boolean("NormalizeVolume", FALSE);
 
 	int err = snd_mixer_selem_get_playback_dB_range(elem, &min, &max);
-	if (err < 0 || min >= max || !normalize_vol()) {
+	if (err < 0 || min >= max || !normalize) {
 		err = snd_mixer_selem_get_playback_volume_range(elem, &min, &max);
 		value = lrint_dir(dvol * (max - min), dir) + min;
 		snd_mixer_selem_set_playback_volume_all(elem, value);
@@ -712,7 +713,9 @@ ismuted(void)
 int
 getvol(void)
 {
-	if (normalize_vol()) {
+	gboolean normalize = prefs_get_boolean("NormalizeVolume", FALSE);
+
+	if (normalize) {
 		return lrint(get_normalized_volume(
 				     elem, SND_MIXER_SCHN_FRONT_RIGHT) * 100);
 	} else {

--- a/src/alsa.c
+++ b/src/alsa.c
@@ -474,12 +474,13 @@ alsaset(void)
 
 	// get selected card
 	assert(active_card == NULL);
-	card_name = get_selected_card();
+	card_name = prefs_get_string("AlsaCard", NULL);
 	DEBUG_PRINT("Selected card: %s", card_name);
 	if (card_name) {
 		active_card = find_card(card_name);
 		g_free(card_name);
 	}
+
 	// if not available, use the default card
 	if (!active_card) {
 		DEBUG_PRINT("Using default soundcard");
@@ -515,7 +516,7 @@ alsaset(void)
 	// is modified. The channel names of the new default card may
 	// not match the channel names of the previous default card.
 	assert(elem == NULL);
-	channel = get_selected_channel(active_card->name);
+	channel = prefs_get_selected_channel(active_card->name);
 	if (channel) {
 		snd_mixer_selem_id_t *sid;
 		snd_mixer_selem_id_alloca(&sid);

--- a/src/alsa.c
+++ b/src/alsa.c
@@ -516,7 +516,7 @@ alsaset(void)
 	// is modified. The channel names of the new default card may
 	// not match the channel names of the previous default card.
 	assert(elem == NULL);
-	channel = prefs_get_selected_channel(active_card->name);
+	channel = prefs_get_channel(active_card->name);
 	if (channel) {
 		snd_mixer_selem_id_t *sid;
 		snd_mixer_selem_id_alloca(&sid);

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -227,7 +227,7 @@ on_ok_button_clicked(G_GNUC_UNUSED GtkButton *button, PrefsData *data)
 	colints[0] = color.red;
 	colints[1] = color.green;
 	colints[2] = color.blue;
-	prefs_set_vol_meter_colors(colints, sizeof colints);
+	prefs_set_vol_meter_colors(colints, 3);
 
 	// alsa card
 	GtkWidget *acc = data->card_combo;

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -238,7 +238,7 @@ on_ok_button_clicked(G_GNUC_UNUSED GtkButton *button, PrefsData *data)
 
 	// alsa card
 	GtkWidget *acc = data->card_combo;
-	gchar *old_card = get_selected_card();
+	gchar *old_card = prefs_get_string("AlsaCard", NULL);
 	gchar *card = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(acc));
 	if (old_card && strcmp(old_card, card))
 		alsa_change = 1;
@@ -247,13 +247,14 @@ on_ok_button_clicked(G_GNUC_UNUSED GtkButton *button, PrefsData *data)
 	// channel
 	GtkWidget *ccc = data->chan_combo;
 	gchar *old_channel = NULL;
-	if (old_card)
-		old_channel = get_selected_channel(old_card);
+	if (old_card) {
+		old_channel = prefs_get_selected_channel(old_card);
+		g_free(old_card);
+	}
 	gchar *chan = gtk_combo_box_text_get_active_text(GTK_COMBO_BOX_TEXT(ccc));
 	if (old_channel) {
 		if (strcmp(old_channel, chan))
 			alsa_change = 1;
-		g_free(old_card);
 		g_free(old_channel);
 	}
 	g_key_file_set_string(keyFile, card, "Channel", chan);

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -215,19 +215,23 @@ on_ok_button_clicked(G_GNUC_UNUSED GtkButton *button, PrefsData *data)
 	prefs_set_integer("VolMeterPos", vmpos);
 
 	GtkWidget *vcb = data->vol_meter_color_button;
+	gdouble colors[3];
 #ifdef WITH_GTK3
 	GdkRGBA color;
 	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(vcb), &color);
-	gdouble colints[3];
+	colors[0] = color.red;
+	colors[1] = color.green;
+	colors[2] = color.blue;
+
 #else
 	GdkColor color;
 	gtk_color_button_get_color(GTK_COLOR_BUTTON(vcb), &color);
-	gint colints[3];
+	colors[0] = (gdouble) color.red / 65536;
+	colors[1] = (gdouble) color.green / 65536;
+	colors[2] = (gdouble) color.blue / 65536;
+
 #endif
-	colints[0] = color.red;
-	colints[1] = color.green;
-	colints[2] = color.blue;
-	prefs_set_vol_meter_colors(colints, 3);
+	prefs_set_vol_meter_colors(colors, 3);
 
 	// alsa card
 	GtkWidget *acc = data->card_combo;

--- a/src/main.c
+++ b/src/main.c
@@ -816,7 +816,7 @@ update_status_icons(void)
 			vol_meter_row[i * 4 + 2] = vol_meter_blue;
 			vol_meter_row[i * 4 + 3] = 255;
 		}
-	} else if (vol_meter_row && prefs_get_boolean("DrawVolMeter", FALSE)) {
+	} else if (vol_meter_row && !prefs_get_boolean("DrawVolMeter", FALSE)) {
 		free(vol_meter_row);
 		vol_meter_row = NULL;
 		if (icon_copy)

--- a/src/main.c
+++ b/src/main.c
@@ -915,7 +915,7 @@ main(int argc, char *argv[])
 	add_pixmap_directory("./data/pixmaps");
 
 	ensure_prefs_dir();
-	load_prefs();
+	prefs_load();
 	cards = NULL;		// so we don't try and free on first run
 	alsa_init();
 	init_libnotify();

--- a/src/main.c
+++ b/src/main.c
@@ -761,9 +761,6 @@ set_vol_meter_color(gdouble nr, gdouble ng, gdouble nb)
 	vol_meter_red = nr * 255;
 	vol_meter_green = ng * 255;
 	vol_meter_blue = nb * 255;
-	if (vol_meter_row)
-		g_free(vol_meter_row);
-	vol_meter_row = NULL;
 }
 
 /**
@@ -782,6 +779,7 @@ update_status_icons(void)
 	for (i = 0; i < N_VOLUME_ICONS; i++)
 		old_icons[i] = status_icons[i];
 
+	/* Handle icons depending on the theme */
 	if (prefs_get_boolean("SystemTheme", FALSE)) {
 		status_icons[VOLUME_MUTED] = get_stock_pixbuf("audio-volume-muted",
 					     size);
@@ -805,23 +803,30 @@ update_status_icons(void)
 		status_icons[VOLUME_HIGH] = create_pixbuf("pnmixer-high.png");
 	}
 
+	/* Handle volume meter */
 	icon_width = gdk_pixbuf_get_height(status_icons[0]);
 	vol_div_factor = ((gdk_pixbuf_get_height(status_icons[0]) - 10) / 100.0);
 	vol_meter_width = 1.25 * icon_width;
 	if (vol_meter_width % 4 != 0)
 		vol_meter_width -= (vol_meter_width % 4);
 
-	if (!vol_meter_row && prefs_get_boolean("DrawVolMeter", FALSE)) {
-		int lim = vol_meter_width / 4;
+	if (prefs_get_boolean("DrawVolMeter", FALSE)) {
+		int lim;
+
+		if (vol_meter_row)
+			g_free(vol_meter_row);
 		vol_meter_row = g_malloc(vol_meter_width * sizeof(guchar));
+
+		lim = vol_meter_width / 4;
 		for (i = 0; i < lim; i++) {
 			vol_meter_row[i * 4] = vol_meter_red;
 			vol_meter_row[i * 4 + 1] = vol_meter_green;
 			vol_meter_row[i * 4 + 2] = vol_meter_blue;
 			vol_meter_row[i * 4 + 3] = 255;
 		}
-	} else if (vol_meter_row && !prefs_get_boolean("DrawVolMeter", FALSE)) {
-		free(vol_meter_row);
+	} else {
+		if (vol_meter_row)
+			g_free(vol_meter_row);
 		vol_meter_row = NULL;
 		if (icon_copy)
 			g_object_unref(icon_copy);

--- a/src/main.c
+++ b/src/main.c
@@ -914,7 +914,7 @@ main(int argc, char *argv[])
 	add_pixmap_directory(PACKAGE_DATA_DIR "/" PACKAGE "/pixmaps");
 	add_pixmap_directory("./data/pixmaps");
 
-	ensure_prefs_dir();
+	prefs_ensure_save_dir();
 	prefs_load();
 	cards = NULL;		// so we don't try and free on first run
 	alsa_init();

--- a/src/main.c
+++ b/src/main.c
@@ -778,8 +778,10 @@ update_status_icons(void)
 	int i, icon_width;
 	GdkPixbuf *old_icons[N_VOLUME_ICONS];
 	int size = tray_icon_size();
+
 	for (i = 0; i < N_VOLUME_ICONS; i++)
 		old_icons[i] = status_icons[i];
+
 	if (prefs_get_boolean("SystemTheme", FALSE)) {
 		status_icons[VOLUME_MUTED] = get_stock_pixbuf("audio-volume-muted",
 					     size);
@@ -802,11 +804,13 @@ update_status_icons(void)
 		status_icons[VOLUME_MEDIUM] = create_pixbuf("pnmixer-medium.png");
 		status_icons[VOLUME_HIGH] = create_pixbuf("pnmixer-high.png");
 	}
+
 	icon_width = gdk_pixbuf_get_height(status_icons[0]);
 	vol_div_factor = ((gdk_pixbuf_get_height(status_icons[0]) - 10) / 100.0);
 	vol_meter_width = 1.25 * icon_width;
 	if (vol_meter_width % 4 != 0)
 		vol_meter_width -= (vol_meter_width % 4);
+
 	if (!vol_meter_row && prefs_get_boolean("DrawVolMeter", FALSE)) {
 		int lim = vol_meter_width / 4;
 		vol_meter_row = g_malloc(vol_meter_width * sizeof(guchar));
@@ -823,10 +827,12 @@ update_status_icons(void)
 			g_object_unref(icon_copy);
 		icon_copy = NULL;
 	}
+
 	draw_offset = prefs_get_integer("VolMeterPos", 0);
 
 	if (tray_icon)
 		on_volume_has_changed();
+
 	for (i = 0; i < N_VOLUME_ICONS; i++)
 		if (old_icons[i])
 			g_object_unref(old_icons[i]);

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -64,7 +64,6 @@ VolDownKey=-1\n\
 AlsaCard=default\n\
 SystemTheme=false"
 
-
 #ifdef WITH_GTK3
 /**
  * Gets the volume meter colors which are drawn on top of the
@@ -187,22 +186,19 @@ load_prefs(void)
 }
 
 /**
- * Gets a boolean value from a keyFile in the specified group at the
- * specified key. On error, returns def as default value.
+ * Gets a boolean value from preferences.
+ * On error, returns def as default value.
  *
- * @param keyFile the GKeyFile to parse
- * @param group the settings group
  * @param key the specific settings key
  * @param def the default value to return on error
- * @return result of g_key_file_get_boolean() or def on error
+ * @return the preference value or def on error
  */
-static gboolean
-g_key_file_get_boolean_with_default(GKeyFile *keyFile,
-				    gchar *group, gchar *key, gboolean def)
+gboolean
+prefs_get_boolean(gchar *key, gboolean def)
 {
 	gboolean ret;
 	GError *error = NULL;
-	ret = g_key_file_get_boolean(keyFile, group, key, &error);
+	ret = g_key_file_get_boolean(keyFile, "PNMixer", key, &error);
 	if (error) {
 		g_error_free(error);
 		return def;
@@ -211,22 +207,19 @@ g_key_file_get_boolean_with_default(GKeyFile *keyFile,
 }
 
 /**
- * Gets an int value from a keyFile in the specified group at the
- * specified key. On error, returns def as default value.
+ * Gets an int value from a preferences.
+ * On error, returns def as default value.
  *
- * @param keyFile the GKeyFile to parse
- * @param group the settings group
  * @param key the specific settings key
  * @param def the default value to return on error
- * @return result of g_key_file_get_boolean() or def on error
+ * @return the preference value or def on error
  */
-static gint
-g_key_file_get_integer_with_default(GKeyFile *keyFile,
-				    gchar *group, gchar *key, gint def)
+gint
+prefs_get_integer(gchar *key, gint def)
 {
 	gint ret;
 	GError *error = NULL;
-	ret = g_key_file_get_integer(keyFile, group, key, &error);
+	ret = g_key_file_get_integer(keyFile, "PNMixer", key, &error);
 	if (error) {
 		g_error_free(error);
 		return def;
@@ -235,25 +228,44 @@ g_key_file_get_integer_with_default(GKeyFile *keyFile,
 }
 
 /**
- * Gets a double value from a keyFile in the specified group at the
- * specified key. On error, returns def as default value.
+ * Gets a double value from preferences.
+ * On error, returns def as default value.
  *
- * @param keyFile the GKeyFile to parse
- * @param group the settings group
  * @param key the specific settings key
  * @param def the default value to return on error
- * @return result of g_key_file_get_boolean() or def on error
+ * @return the preference value or def on error
  */
-static gdouble
-g_key_file_get_double_with_default(GKeyFile *keyFile,
-				   gchar *group, gchar *key, gdouble def)
+gdouble
+prefs_get_double(gchar *key, gdouble def)
 {
 	gdouble ret;
 	GError *error = NULL;
-	ret = g_key_file_get_double(keyFile, group, key, &error);
+	ret = g_key_file_get_double(keyFile, "PNMixer", key, &error);
 	if (error) {
 		g_error_free(error);
 		return def;
+	}
+	return ret;
+}
+
+/**
+ * Gets a string value from preferences.
+ * On error, returns def as default value.
+ *
+ * @param key the specific settings key
+ * @param def the default value to return on error
+ * @return the preference value or def on error, must be freed.
+ */
+gchar *
+prefs_get_string(gchar *key, const gchar *def)
+{
+	gchar *ret = NULL;
+	GError *error = NULL;
+
+	ret = g_key_file_get_string(keyFile, "PNMixer", key, &error);
+	if (error) {
+		g_error_free(error);
+		return g_strdup(def);
 	}
 	return ret;
 }
@@ -285,24 +297,12 @@ gtk_combo_box_set_active_id(GtkComboBox *combo_box, const gchar *active_id)
 static void
 set_notification_options(void)
 {
-	enable_noti =
-		g_key_file_get_boolean_with_default(keyFile, "PNMixer",
-				"EnableNotifications", FALSE);
-	hotkey_noti =
-		g_key_file_get_boolean_with_default(keyFile, "PNMixer",
-				"HotkeyNotifications", TRUE);
-	mouse_noti =
-		g_key_file_get_boolean_with_default(keyFile, "PNMixer",
-				"MouseNotifications", TRUE);
-	popup_noti =
-		g_key_file_get_boolean_with_default(keyFile, "PNMixer",
-				"PopupNotifications", FALSE);
-	external_noti =
-		g_key_file_get_boolean_with_default(keyFile, "PNMixer",
-				"ExternalNotifications", FALSE);
-	noti_timeout =
-		g_key_file_get_integer_with_default(keyFile, "PNMixer",
-				"NotificationTimeout", 1500);
+	enable_noti = prefs_get_boolean("EnableNotifications", FALSE);
+	hotkey_noti = prefs_get_boolean("HotkeyNotifications", TRUE);
+	mouse_noti = prefs_get_boolean("MouseNotifications", TRUE);
+	popup_noti = prefs_get_boolean("PopupNotifications", FALSE);
+	external_noti = prefs_get_boolean("ExternalNotifications", FALSE);
+	noti_timeout = prefs_get_integer("NotificationTimeout", 1500);
 }
 
 /**
@@ -319,32 +319,21 @@ apply_prefs(gint alsa_change)
 #else
 	gint *vol_meter_clrs;
 #endif
-	scroll_step = g_key_file_get_integer_with_default(keyFile, "PNMixer",
-		"ScrollStep", 5);
+	scroll_step = prefs_get_integer("ScrollStep", 5);
 	gtk_adjustment_set_page_increment(vol_adjustment, scroll_step);
 
-	fine_scroll_step = g_key_file_get_integer_with_default(keyFile,
-		"PNMixer", "FineScrollStep", 1);
+	fine_scroll_step = prefs_get_integer("FineScrollStep", 1);
 	gtk_adjustment_set_step_increment(vol_adjustment, fine_scroll_step);
 
-	if (g_key_file_get_boolean_with_default(keyFile, "PNMixer",
-						"EnableHotKeys", FALSE)) {
+	if (prefs_get_boolean("EnableHotKeys", FALSE)) {
 		gint mk, uk, dk, mm, um, dm, hstep;
-		mk = g_key_file_get_integer_with_default(keyFile, "PNMixer",
-				"VolMuteKey", -1);
-		uk = g_key_file_get_integer_with_default(keyFile, "PNMixer",
-				"VolUpKey", -1);
-		dk = g_key_file_get_integer_with_default(keyFile, "PNMixer",
-				"VolDownKey", -1);
-		mm = g_key_file_get_integer_with_default(keyFile, "PNMixer",
-				"VolMuteMods", 0);
-		um = g_key_file_get_integer_with_default(keyFile, "PNMixer",
-				"VolUpMods", 0);
-		dm = g_key_file_get_integer_with_default(keyFile, "PNMixer",
-				"VolDownMods", 0);
-		hstep =
-			g_key_file_get_integer_with_default(keyFile, "PNMixer",
-					"HotkeyVolumeStep", 1);
+		mk = prefs_get_integer("VolMuteKey", -1);
+		uk = prefs_get_integer("VolUpKey", -1);
+		dk = prefs_get_integer("VolDownKey", -1);
+		mm = prefs_get_integer("VolMuteMods", 0);
+		um = prefs_get_integer("VolUpMods", 0);
+		dm = prefs_get_integer("VolDownMods", 0);
+		hstep = prefs_get_integer("HotkeyVolumeStep", 1);
 		grab_keys(mk, uk, dk, mm, um, dm, hstep);
 	} else
 		// will actually just ungrab everything
@@ -364,19 +353,6 @@ apply_prefs(gint alsa_change)
 }
 
 /**
- * Gets the currently selected Alsa Card from the global keyFile
- * and returns the result.
- *
- * @return the currently selected Alsa Card as a newly allocated string,
- * NULL on failure
- */
-gchar *
-get_selected_card(void)
-{
-	return g_key_file_get_string(keyFile, "PNMixer", "AlsaCard", NULL);
-}
-
-/**
  * Gets the currently selected channel of the specified Alsa Card
  * from the global keyFile and returns the result.
  *
@@ -385,7 +361,7 @@ get_selected_card(void)
  * NULL on failure
  */
 gchar *
-get_selected_channel(gchar *card)
+prefs_get_selected_channel(const gchar *card)
 {
 	if (!card)
 		return NULL;
@@ -448,7 +424,7 @@ fill_card_combo(GtkWidget *combo, GtkWidget *channels_combo)
 			continue;
 		}
 		if (active_card && !strcmp(c->name, active_card->name)) {
-			gchar *sel_chan = get_selected_channel(c->name);
+			gchar *sel_chan = prefs_get_selected_channel(c->name);
 			sidx = idx;
 			fill_channel_combo(c->channels, channels_combo, sel_chan);
 			if (sel_chan)
@@ -482,7 +458,7 @@ on_card_changed(GtkComboBox *box, PrefsData *data)
 	g_free(card_name);
 
 	if (card) {
-		gchar *sel_chan = get_selected_channel(card->name);
+		gchar *sel_chan = prefs_get_selected_channel(card->name);
 		fill_channel_combo(card->channels, data->chan_combo, sel_chan);
 		g_free(sel_chan);
 	}
@@ -597,12 +573,13 @@ static const char *vol_cmds[] = { "pavucontrol",
  * from vol_cmds or NULL on failure
  */
 gchar *
-get_vol_command(void)
+prefs_get_vol_command(void)
 {
-	if (g_key_file_has_key(keyFile, "PNMixer", "VolumeControlCommand", NULL))
-		return g_key_file_get_string(keyFile, "PNMixer",
-					     "VolumeControlCommand", NULL);
-	else {
+	gchar *ret;
+
+	ret = prefs_get_string("VolumeControlCommand", NULL);
+
+	if (ret == NULL) {
 		gchar buf[256];
 		const char **cmd = vol_cmds;
 		while (*cmd) {
@@ -611,8 +588,9 @@ get_vol_command(void)
 				return g_strdup(*cmd);
 			cmd++;
 		}
-		return NULL;
 	}
+
+	return ret;
 }
 
 /**
@@ -823,7 +801,7 @@ create_prefs_window(void)
 	GdkColor vol_meter_color_button_color;
 	gint *vol_meter_clrs;
 #endif
-	gchar *vol_cmd, *uifile, *custcmd;
+	gchar *uifile, *slider_orientation, *vol_cmd, *custcmd;
 
 	PrefsData *prefs_data;
 
@@ -890,38 +868,44 @@ create_prefs_window(void)
 #undef GO
 
 	// slider orientation
+	slider_orientation = prefs_get_string("SliderOrientation", NULL);
+	if (slider_orientation) {
+		gtk_combo_box_set_active_id
+		(GTK_COMBO_BOX(prefs_data->slider_orientation_combo),
+		 slider_orientation);
+		g_free(slider_orientation);
+	}
+
 	gtk_combo_box_set_active_id
 	(GTK_COMBO_BOX(prefs_data->slider_orientation_combo),
-	 g_key_file_get_string(keyFile, "PNMixer", "SliderOrientation", NULL));
+	 prefs_get_string("SliderOrientation", NULL));
 	
 	// vol text display
 	gtk_toggle_button_set_active
 	(GTK_TOGGLE_BUTTON(prefs_data->vol_text_check),
-	 g_key_file_get_boolean_with_default(keyFile, "PNMixer",
-					     "DisplayTextVolume", FALSE));
+	 prefs_get_boolean("DisplayTextVolume", FALSE));
+
 	gtk_combo_box_set_active
 	(GTK_COMBO_BOX(prefs_data->vol_pos_combo),
-	 g_key_file_get_integer_with_default(keyFile, "PNMixer",
-					     "TextVolumePosition", 0));
+	 prefs_get_integer("TextVolumePosition", 0));
 
 	// volume meter
 	gtk_toggle_button_set_active
 	(GTK_TOGGLE_BUTTON(prefs_data->draw_vol_check),
-	 g_key_file_get_boolean_with_default(keyFile, "PNMixer",
-					     "DrawVolMeter", FALSE));
+	 prefs_get_boolean("DrawVolMeter", FALSE));
+
 	gtk_adjustment_set_upper
 	(GTK_ADJUSTMENT(gtk_builder_get_object(builder,
-					       "vol_meter_pos_adjustment")),
+	                                       "vol_meter_pos_adjustment")),
 	 tray_icon_size() - 10);
+
 	gtk_spin_button_set_value
 	(GTK_SPIN_BUTTON(prefs_data->vol_meter_pos_spin),
-	 g_key_file_get_integer_with_default(keyFile, "PNMixer",
-					     "VolMeterPos", 0));
+	 prefs_get_integer("VolMeterPos", 0));
 
 	gtk_toggle_button_set_active
 	(GTK_TOGGLE_BUTTON(prefs_data->system_theme),
-	 g_key_file_get_boolean_with_default(keyFile, "PNMixer",
-		 "SystemTheme", FALSE));
+	 prefs_get_boolean("SystemTheme", FALSE));
 
 	// set color button color
 	vol_meter_clrs = get_vol_meter_colors();
@@ -944,33 +928,33 @@ create_prefs_window(void)
 	// volume normalization (ALSA mapped)
 	gtk_toggle_button_set_active
 	(GTK_TOGGLE_BUTTON(prefs_data->normalize_vol_check),
-	 g_key_file_get_boolean_with_default(keyFile, "PNMixer",
-					     "NormalizeVolume", FALSE));
+	 prefs_get_boolean("NormalizeVolume", FALSE));
 
 	// volume command
-	vol_cmd = get_vol_command();
+	vol_cmd = prefs_get_vol_command();
 	if (vol_cmd) {
 		gtk_entry_set_text(GTK_ENTRY(prefs_data->vol_control_entry), vol_cmd);
 		g_free(vol_cmd);
 	}
+	                           
 	// volume scroll steps
-	gtk_spin_button_set_value(GTK_SPIN_BUTTON(prefs_data->scroll_step_spin),
-		g_key_file_get_double_with_default(keyFile, "PNMixer",
-			"ScrollStep", 5));
-	gtk_spin_button_set_value(GTK_SPIN_BUTTON(prefs_data->fine_scroll_step_spin),
-		g_key_file_get_double_with_default(keyFile, "PNMixer",
-			"FineScrollStep", 1));
+	gtk_spin_button_set_value
+	(GTK_SPIN_BUTTON(prefs_data->scroll_step_spin),
+	 prefs_get_double("ScrollStep", 5));
+
+	gtk_spin_button_set_value
+	(GTK_SPIN_BUTTON(prefs_data->fine_scroll_step_spin),
+	 prefs_get_double("FineScrollStep", 1));
 
 	//  middle click
-	gtk_combo_box_set_active(GTK_COMBO_BOX(prefs_data->middle_click_combo),
-				 g_key_file_get_integer_with_default(keyFile, "PNMixer",
-						 "MiddleClickAction", 0));
+	gtk_combo_box_set_active
+	(GTK_COMBO_BOX(prefs_data->middle_click_combo),
+	 prefs_get_integer("MiddleClickAction", 0));
 
 	// custom command
 	gtk_entry_set_invisible_char(GTK_ENTRY(prefs_data->custom_entry), 8226);
 
-	custcmd = g_key_file_get_string(keyFile, "PNMixer",
-					"CustomCommand", NULL);
+	custcmd = prefs_get_string("CustomCommand", NULL);
 	if (custcmd) {
 		gtk_entry_set_text(GTK_ENTRY(prefs_data->custom_entry), custcmd);
 		g_free(custcmd);
@@ -986,33 +970,27 @@ create_prefs_window(void)
 	// hotkeys
 	gtk_toggle_button_set_active
 	(GTK_TOGGLE_BUTTON(prefs_data->enable_hotkeys_check),
-	 g_key_file_get_boolean_with_default(keyFile, "PNMixer",
-					     "EnableHotKeys", FALSE));
+	 prefs_get_boolean("EnableHotKeys", FALSE));
 
 	// hotkey step
-	gtk_spin_button_set_value(GTK_SPIN_BUTTON(prefs_data->hotkey_vol_spin),
-				  g_key_file_get_integer_with_default(keyFile, "PNMixer",
-						  "HotkeyVolumeStep", 1));
+	gtk_spin_button_set_value
+	(GTK_SPIN_BUTTON(prefs_data->hotkey_vol_spin),
+	 prefs_get_integer("HotkeyVolumeStep", 1));
 
 	if (g_key_file_has_key(keyFile, "PNMixer", "VolMuteKey", NULL))
 		set_label_for_keycode(prefs_data->mute_hotkey_label,
-				      g_key_file_get_integer(keyFile, "PNMixer", "VolMuteKey",
-						      NULL),
-				      g_key_file_get_integer_with_default(keyFile, "PNMixer",
-						      "VolMuteMods", 0));
+		                      prefs_get_integer("VolMuteKey", 0),
+		                      prefs_get_integer("VolMuteMods", 0));
 
 	if (g_key_file_has_key(keyFile, "PNMixer", "VolUpKey", NULL))
 		set_label_for_keycode(prefs_data->up_hotkey_label,
-				      g_key_file_get_integer(keyFile, "PNMixer",
-						      "VolUpKey", NULL),
-				      g_key_file_get_integer_with_default(keyFile, "PNMixer",
-						      "VolUpMods", 0));
+		                      prefs_get_integer("VolUpKey", 0),
+		                      prefs_get_integer("VolUpMods", 0));
+
 	if (g_key_file_has_key(keyFile, "PNMixer", "VolDownKey", NULL))
 		set_label_for_keycode(prefs_data->down_hotkey_label,
-				      g_key_file_get_integer(keyFile, "PNMixer", "VolDownKey",
-						      NULL),
-				      g_key_file_get_integer_with_default(keyFile, "PNMixer",
-						      "VolDownMods", 0));
+		                      prefs_get_integer("VolDownKey", 0),
+		                      prefs_get_integer("VolDownMods", 0));
 
 	on_hotkey_toggle(GTK_TOGGLE_BUTTON(prefs_data->enable_hotkeys_check),
 			 prefs_data);

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -370,8 +370,8 @@ void
 prefs_load(void)
 {
 	GError *err = NULL;
-	gchar *filename = g_strconcat(g_get_user_config_dir(),
-				      "/pnmixer/config", NULL);
+	gchar *filename = g_build_filename(g_get_user_config_dir(),
+	                                   "pnmixer", "config", NULL);
 
 	if (keyFile != NULL)
 		g_key_file_free(keyFile);
@@ -408,8 +408,8 @@ prefs_save(void)
 {
 	gsize len;
 	GError *err = NULL;
-	gchar *filename = g_strconcat(g_get_user_config_dir(),
-				      "/pnmixer/config", NULL);
+	gchar *filename = g_build_filename(g_get_user_config_dir(),
+	                                   "pnmixer", "config", NULL);
 	gchar *filedata = g_key_file_to_data(keyFile, &len, NULL);
 
 	g_file_set_contents(filename, filedata, len, &err);
@@ -430,7 +430,8 @@ prefs_save(void)
 void
 prefs_ensure_save_dir(void)
 {
-	gchar *prefs_dir = g_strconcat(g_get_user_config_dir(), "/pnmixer", NULL);
+	gchar *prefs_dir = g_build_filename(g_get_user_config_dir(),
+	                                   "pnmixer", NULL);
 
 	if (!g_file_test(prefs_dir, G_FILE_TEST_IS_DIR)) {
 		if (g_file_test(prefs_dir, G_FILE_TEST_EXISTS))

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -363,28 +363,6 @@ prefs_set_vol_meter_colors(gint *colors, gsize n)
 #endif
 
 /**
- * Checks if the preferences dir is present (creates it if not) and
- * accessible. Reports errors via report_error().
- */
-void
-ensure_prefs_dir(void)
-{
-	gchar *prefs_dir = g_strconcat(g_get_user_config_dir(), "/pnmixer", NULL);
-	if (!g_file_test(prefs_dir, G_FILE_TEST_IS_DIR)) {
-		if (g_file_test(prefs_dir, G_FILE_TEST_EXISTS))
-			report_error(_
-				     ("Error: %s exists but is not a directory, will "
-				      "not be able to save preferences."), prefs_dir);
-		else {
-			if (g_mkdir(prefs_dir, S_IRWXU))
-				report_error(_("Couldn't make prefs directory: %s"),
-					     strerror(errno));
-		}
-	}
-	g_free(prefs_dir);
-}
-
-/**
  * Loads the preferences from the config file to the keyFile object (GKeyFile type).
  * Creates the keyFile object if it doesn't exist.
  */
@@ -443,6 +421,30 @@ prefs_save(void)
 
 	g_free(filename);
 	g_free(filedata);
+}
+
+/**
+ * Checks if the preferences dir for saving is present and accessible.
+ * Creates it if doesn't exist. Reports errors via report_error().
+ */
+void
+prefs_ensure_save_dir(void)
+{
+	gchar *prefs_dir = g_strconcat(g_get_user_config_dir(), "/pnmixer", NULL);
+
+	if (!g_file_test(prefs_dir, G_FILE_TEST_IS_DIR)) {
+		if (g_file_test(prefs_dir, G_FILE_TEST_EXISTS))
+			report_error(_
+				     ("Error: %s exists but is not a directory, will "
+				      "not be able to save preferences."), prefs_dir);
+		else {
+			if (g_mkdir(prefs_dir, S_IRWXU))
+				report_error(_("Couldn't make prefs directory: %s"),
+					     strerror(errno));
+		}
+	}
+
+	g_free(prefs_dir);
 }
 
 /**

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -953,6 +953,7 @@ create_prefs_window(void)
 	vol_meter_color_button_color.red = vol_meter_clrs[0];
 	vol_meter_color_button_color.green = vol_meter_clrs[1];
 	vol_meter_color_button_color.blue = vol_meter_clrs[2];
+	vol_meter_color_button_color.alpha = 1.0;
 
 	gtk_color_chooser_set_rgba(
 	GTK_COLOR_CHOOSER(prefs_data->vol_meter_color_button),

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -270,26 +270,6 @@ prefs_get_string(gchar *key, const gchar *def)
 	return ret;
 }
 
-#ifndef WITH_GTK3
-/**
- * Gtk2 cludge
- * Gtk2 ComboBoxes don't have ids. We workaround that by
- * mapping the id with a ComboBox index. We're fine as long
- * as nobody changes the content of the ComboBox.
- *
- * @param combo_box a GtkComboBox
- * @param active_id the ID of the row to select
- */
-static void
-gtk_combo_box_set_active_id(GtkComboBox *combo_box, const gchar *active_id)
-{
-	if (!strcmp(active_id, "horizontal"))
-		return gtk_combo_box_set_active(combo_box, 1);
-
-	return gtk_combo_box_set_active(combo_box, 0);
-}
-#endif
-
 /**
  * Sets the global options enable_noti, hotkey_noti, mouse_noti, popup_noti,
  * noti_timeout and external_noti from the user settings.
@@ -870,9 +850,17 @@ create_prefs_window(void)
 	// slider orientation
 	slider_orientation = prefs_get_string("SliderOrientation", NULL);
 	if (slider_orientation) {
-		gtk_combo_box_set_active_id
-		(GTK_COMBO_BOX(prefs_data->slider_orientation_combo),
-		 slider_orientation);
+		GtkComboBox *combo_box = GTK_COMBO_BOX
+			(prefs_data->slider_orientation_combo);
+#ifndef WITH_GTK3
+		/* Gtk2 ComboBoxes don't have item ids */
+		if (!strcmp(slider_orientation, "horizontal"))
+			gtk_combo_box_set_active(combo_box, 1);
+		else
+			gtk_combo_box_set_active(combo_box, 0);
+#else
+		gtk_combo_box_set_active_id(combo_box, slider_orientation);
+#endif
 		g_free(slider_orientation);
 	}
 

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -871,21 +871,6 @@ set_label_for_keycode(GtkWidget *label, gint code, GdkModifierType mods)
 }
 
 /**
- * Checks whether NormalizeVolume preference is set in the user config,
- * by reading the global keyFile.
- *
- * @return TRUE if it's set, FALSE otherwise
- */
-gboolean
-normalize_vol(void)
-{
-	if (g_key_file_has_key(keyFile, "PNMixer", "NormalizeVolume", NULL))
-		return (g_key_file_get_boolean(keyFile, "PNMixer",
-					       "NormalizeVolume", NULL));
-	return FALSE;
-}
-
-/**
  * Creates the whole preferences window by reading prefs-gtk3.glade
  * or prefs-gtk2.glade and returns the result.
  *

--- a/src/prefs.c
+++ b/src/prefs.c
@@ -971,10 +971,6 @@ create_prefs_window(void)
 #endif
 		g_free(slider_orientation);
 	}
-
-	gtk_combo_box_set_active_id
-	(GTK_COMBO_BOX(prefs_data->slider_orientation_combo),
-	 prefs_get_string("SliderOrientation", NULL));
 	
 	// vol text display
 	gtk_toggle_button_set_active

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -22,7 +22,6 @@
 
 #include "support.h"
 
-GKeyFile *keyFile;
 gint scroll_step, fine_scroll_step;
 gboolean enable_noti, hotkey_noti, mouse_noti, popup_noti, external_noti;
 gint noti_timeout;
@@ -32,14 +31,32 @@ gboolean prefs_get_boolean(gchar *key, gboolean def);
 gint prefs_get_integer(gchar *key, gint def);
 gdouble prefs_get_double(gchar *key, gdouble def);
 gchar *prefs_get_string(gchar *key, const gchar *def);
-
-gchar *prefs_get_selected_channel(const gchar *);
+gchar *prefs_get_channel(const gchar *card);
 gchar *prefs_get_vol_command(void);
+#ifdef WITH_GTK3
+gdouble *prefs_get_vol_meter_colors(void);
+#else
+gint *prefs_get_vol_meter_colors(void);
+#endif
+
+void prefs_set_boolean(const gchar *key, gboolean value);
+void prefs_set_integer(const gchar *key, gint value);
+void prefs_set_double(const gchar *key, gdouble value);
+void prefs_set_string(const gchar *key, const gchar *value);
+
+void prefs_set_channel(const gchar *card, const gchar *channel);
+#ifdef WITH_GTK3
+void prefs_set_vol_meter_colors(gdouble *colors, gsize n);
+#else
+void prefs_set_vol_meter_colors(gint *colors, gsize n);
+#endif
+
+void prefs_load(void);
+void prefs_save(void);
 
 GtkWidget *create_prefs_window(void);
 void ensure_prefs_dir(void);
 void apply_prefs(gint);
-void load_prefs(void);
 void acquire_hotkey(const char *, PrefsData *);
 gboolean normalize_vol(void);
 

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -52,9 +52,10 @@ void prefs_set_vol_meter_colors(gint *colors, gsize n);
 
 void prefs_load(void);
 void prefs_save(void);
+void prefs_ensure_save_dir(void);
+
 
 GtkWidget *create_prefs_window(void);
-void ensure_prefs_dir(void);
 void apply_prefs(gint);
 void acquire_hotkey(const char *, PrefsData *);
 gboolean normalize_vol(void);

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -57,6 +57,5 @@ void prefs_ensure_save_dir(void);
 GtkWidget *create_prefs_window(void);
 void apply_prefs(gint);
 void acquire_hotkey(const char *, PrefsData *);
-gboolean normalize_vol(void);
 
 #endif				// PREFS_H_

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -28,13 +28,19 @@ gboolean enable_noti, hotkey_noti, mouse_noti, popup_noti, external_noti;
 gint noti_timeout;
 GtkIconTheme *icon_theme;
 
+gboolean prefs_get_boolean(gchar *key, gboolean def);
+gint prefs_get_integer(gchar *key, gint def);
+gdouble prefs_get_double(gchar *key, gdouble def);
+gchar *prefs_get_string(gchar *key, const gchar *def);
+
+gchar *prefs_get_vol_command(void);
+gchar *prefs_get_selected_channel(const gchar *);
+
+
 GtkWidget *create_prefs_window(void);
 void ensure_prefs_dir(void);
 void apply_prefs(gint);
 void load_prefs(void);
-gchar *get_vol_command(void);
-gchar *get_selected_card(void);
-gchar *get_selected_channel(gchar *);
 void acquire_hotkey(const char *, PrefsData *);
 gboolean normalize_vol(void);
 

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -33,22 +33,14 @@ gdouble  prefs_get_double(gchar *key, gdouble def);
 gchar   *prefs_get_string(gchar *key, const gchar *def);
 gchar   *prefs_get_channel(const gchar *card);
 gchar   *prefs_get_vol_command(void);
-#ifdef WITH_GTK3
 gdouble *prefs_get_vol_meter_colors(void);
-#else
-gint    *prefs_get_vol_meter_colors(void);
-#endif
 
 void prefs_set_boolean(const gchar *key, gboolean value);
 void prefs_set_integer(const gchar *key, gint value);
 void prefs_set_double(const gchar *key, gdouble value);
 void prefs_set_string(const gchar *key, const gchar *value);
 void prefs_set_channel(const gchar *card, const gchar *channel);
-#ifdef WITH_GTK3
 void prefs_set_vol_meter_colors(gdouble *colors, gsize n);
-#else
-void prefs_set_vol_meter_colors(gint *colors, gsize n);
-#endif
 
 void prefs_load(void);
 void prefs_save(void);

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -28,22 +28,21 @@ gint noti_timeout;
 GtkIconTheme *icon_theme;
 
 gboolean prefs_get_boolean(gchar *key, gboolean def);
-gint prefs_get_integer(gchar *key, gint def);
-gdouble prefs_get_double(gchar *key, gdouble def);
-gchar *prefs_get_string(gchar *key, const gchar *def);
-gchar *prefs_get_channel(const gchar *card);
-gchar *prefs_get_vol_command(void);
+gint     prefs_get_integer(gchar *key, gint def);
+gdouble  prefs_get_double(gchar *key, gdouble def);
+gchar   *prefs_get_string(gchar *key, const gchar *def);
+gchar   *prefs_get_channel(const gchar *card);
+gchar   *prefs_get_vol_command(void);
 #ifdef WITH_GTK3
 gdouble *prefs_get_vol_meter_colors(void);
 #else
-gint *prefs_get_vol_meter_colors(void);
+gint    *prefs_get_vol_meter_colors(void);
 #endif
 
 void prefs_set_boolean(const gchar *key, gboolean value);
 void prefs_set_integer(const gchar *key, gint value);
 void prefs_set_double(const gchar *key, gdouble value);
 void prefs_set_string(const gchar *key, const gchar *value);
-
 void prefs_set_channel(const gchar *card, const gchar *channel);
 #ifdef WITH_GTK3
 void prefs_set_vol_meter_colors(gdouble *colors, gsize n);

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -33,9 +33,8 @@ gint prefs_get_integer(gchar *key, gint def);
 gdouble prefs_get_double(gchar *key, gdouble def);
 gchar *prefs_get_string(gchar *key, const gchar *def);
 
-gchar *prefs_get_vol_command(void);
 gchar *prefs_get_selected_channel(const gchar *);
-
+gchar *prefs_get_vol_command(void);
 
 GtkWidget *create_prefs_window(void);
 void ensure_prefs_dir(void);

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -54,7 +54,6 @@ void prefs_load(void);
 void prefs_save(void);
 void prefs_ensure_save_dir(void);
 
-
 GtkWidget *create_prefs_window(void);
 void apply_prefs(gint);
 void acquire_hotkey(const char *, PrefsData *);


### PR DESCRIPTION
Hi,

I had some time and inspiration, so I started some code rework on PNMixer.

To me PNMixer code is a little bit of a maze, and I think reworking it is really needed to ease the maintenance. I hope you agree with me.

So I started by reworking a little bit the preferences files, mainly creating get/set accessors to wrap GKeyFile calls, so that prefs.h offer a consistent API. Functions also don't need to expose all the arguments that GKeyFile calls needed. As a result, is much more readable.

So I would like to merge that if nobody's is against. Since it moves / rename a lot of stuff here and there, I just want to be sure that you don't have work in progress.

Following that, I'd like to keep on improving PNMixer code. I'd like to separate the UI related code from the rest, probably having some files like `ui-prefs.c`, `ui-popup.c`. So that in the end UI code is isolated in ui-* files, so we can find our way easily. That would probably means merging the `callbacks.c` file with the new ui-files.

Managing callbacks in a separate file never made sense to me anyway. At the moment, we have two big pieces of code, `create_prefs_window()` and `on_ok_button_clicked()`, that are managed in two different files. But these two functions apply to preferences window, and are kind of counterpart. It would be really nicer to have both in one file. That's what I intend to do.

Furthermore, at the moment we have callbacks that are handled in callbacks.c, but other callbacks are handled in other file (like main.c). So, one more reason to get rid of `callbacks.c`.

So, if nobody's against, I'll merge the current PR, and keep on improving code base in the following days. That mean nobody should work on PNMixer at that time, just to avoid painful merge conflicts afterward.