### PR TITLE
Fix header for notif.c, when libnotify is disable.

### DIFF
--- a/src/notif.c
+++ b/src/notif.c
@@ -21,7 +21,10 @@
 
 #include <math.h>
 #include <glib.h>
+
+#ifdef HAVE_LIBN
 #include <libnotify/notify.h>
+#endif
 
 #include "audio.h"
 #include "prefs.h"


### PR DESCRIPTION
If libnotify is disable don't include <libnotify/notify.h>