### PR TITLE
Make the build reproducible.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,6 +7,8 @@ AM_INIT_AUTOMAKE([foreign])
 AM_MAINTAINER_MODE
 AC_CONFIG_HEADERS([src/config.h])
 
+AM_CONDITIONAL([WITH_SOURCE_DATE_EPOCH], [test "$SOURCE_DATE_EPOCH" != ""])
+
 # ===================================================== #
 #                  Basic compiler settings              #
 # ===================================================== #

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,5 +1,10 @@
 .0.1:
-	@sed -e "s/!VERSION!/@PACKAGE_VERSION@/g" -e "s/!DATE!/`date '+%B %Y'`/g" < $*.0 > $@
+	@sed -e "s/!VERSION!/@PACKAGE_VERSION@/g" < $*.0 > $@
+if WITH_SOURCE_DATE_EPOCH
+	@sed -e "s/!DATE!/`LC_ALL=C date --utc --date="@$(SOURCE_DATE_EPOCH)" '+%B %Y'`/g" < $*.0 > $@
+else
+	@sed -e "s/!DATE!/`date '+%B %Y'`/g" < $*.0 > $@
+endif
 	@echo Built $*.1 from template
 
 manpages_in_files = $(wildcard *.0)


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that pnmixer could not be built reproducibly as it embeds the current
time in a locale and timezone-varying manner

 [0] https://reproducible-builds.org/

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>