### PR TITLE
Fix assertion crashes when volume > 100

### DIFF
--- a/src/ui-tray-icon.c
+++ b/src/ui-tray-icon.c
@@ -267,7 +267,7 @@ vol_meter_draw(VolMeter *vol_meter, GdkPixbuf *pixbuf, int volume)
 	g_assert(x >= 0 && x + vm_width <= icon_width);
 
 	y = vol_meter->y_offset_pct * icon_height / 100;
-	vm_height = (icon_height - (y * 2)) * (volume / 100.0);
+	vm_height = (icon_height - (y * 2)) * (fminf(volume, 100.0) / 100.0);
 	g_assert(y >= 0 && y + vm_height <= icon_height);
 
 	/* Let's check if the icon width changed, in which case we


### PR DESCRIPTION
With PulseAudio, it is perfectly possible for the volume to go above 100%. In fact, even the GUI tools usually support up to 130, but one can go up to MAXINT with pacmd `--allow-boost`.
When volume meter is being displayed on the tray icon, going above ~110 crashes `pnmixer` (actual number depends on the icon size of course).
Full native support of PA is a lot of work, but like you say in the readme, it works rather well through the alsa backend anyway. This crash is the only problem I've seen in the last couple of years and I think this is a reasonable and simple fix.